### PR TITLE
Feature/call eligibility service

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/exception/EligibilityClientException.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/exception/EligibilityClientException.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpStatus;
  */
 public class EligibilityClientException extends RuntimeException {
 
+    private static final long serialVersionUID = 1L;
+
     public EligibilityClientException(HttpStatus httpStatus) {
         super("Response code from Eligibility service was not OK, received: " + httpStatus.value());
     }

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/exception/EligibilityClientException.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/exception/EligibilityClientException.java
@@ -1,0 +1,13 @@
+package uk.gov.dhsc.htbhf.claimant.exception;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * Exception used when calling the Eligibility Service from the {@link uk.gov.dhsc.htbhf.claimant.service.EligibilityClient}.
+ */
+public class EligibilityClientException extends RuntimeException {
+
+    public EligibilityClientException(HttpStatus httpStatus) {
+        super("Response code from Eligibility service was not OK, received: " + httpStatus.value());
+    }
+}

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/model/eligibility/EligibilityResponse.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/model/eligibility/EligibilityResponse.java
@@ -1,0 +1,15 @@
+package uk.gov.dhsc.htbhf.claimant.model.eligibility;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class EligibilityResponse {
+
+    @JsonProperty("eligibilityStatus")
+    private EligibilityStatus eligibilityStatus;
+}

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/model/eligibility/EligibilityStatus.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/model/eligibility/EligibilityStatus.java
@@ -1,0 +1,17 @@
+package uk.gov.dhsc.htbhf.claimant.model.eligibility;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+
+/**
+ * The possible states that a claim can be in according to the DWP.
+ */
+@AllArgsConstructor
+@JsonFormat(shape = JsonFormat.Shape.STRING)
+public enum EligibilityStatus {
+
+    ELIGIBLE,
+    INELIGIBLE,
+    PENDING,
+    NOMATCH
+}

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/model/eligibility/PersonDTO.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/model/eligibility/PersonDTO.java
@@ -1,0 +1,34 @@
+package uk.gov.dhsc.htbhf.claimant.model.eligibility;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import uk.gov.dhsc.htbhf.claimant.model.AddressDTO;
+
+import java.time.LocalDate;
+
+/**
+ * Representation of what is required to  call the Eligibility Service.
+ */
+@Data
+@Builder
+@AllArgsConstructor(onConstructor_ = {@JsonCreator})
+public class PersonDTO {
+
+    @JsonProperty("firstName")
+    private final String firstName;
+
+    @JsonProperty("lastName")
+    private final String lastName;
+
+    @JsonProperty("nino")
+    private final String nino;
+
+    @JsonProperty("dateOfBirth")
+    private final LocalDate dateOfBirth;
+
+    @JsonProperty("address")
+    private final AddressDTO address;
+}

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/ClaimService.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/ClaimService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.dhsc.htbhf.claimant.entity.Claim;
 import uk.gov.dhsc.htbhf.claimant.entity.Claimant;
+import uk.gov.dhsc.htbhf.claimant.exception.EligibilityClientException;
 import uk.gov.dhsc.htbhf.claimant.repository.ClaimantRepository;
 
 @Service
@@ -13,9 +14,16 @@ import uk.gov.dhsc.htbhf.claimant.repository.ClaimantRepository;
 public class ClaimService {
 
     private final ClaimantRepository claimantRepository;
+    private final EligibilityClient client;
 
     public void createClaim(Claim claim) {
         Claimant claimant = claim.getClaimant();
+        try {
+            client.checkEligibility(claimant);
+        } catch (EligibilityClientException e) {
+            log.error("Unexpected exception caught trying to retrieve the Eligibility status from the Eligibility Service", e);
+        }
+        //TODO - Add eligibility status to the Claimant and to the database.
         claimantRepository.save(claimant);
         log.info("Saved new claimant: {}", claimant.getId());
     }

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/ClaimService.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/ClaimService.java
@@ -16,14 +16,22 @@ public class ClaimService {
     private final ClaimantRepository claimantRepository;
     private final EligibilityClient client;
 
+    /**
+     * NOTE: This is only here to keep Checkstyle happy - we'll remove as we resolve the TODOs.
+     * TODO - If there is any Exception catch at this point, we need to throw an Exception to make sure that the
+     *        failure goes back to the UI.
+     * TODO - Add eligibility status to the Claimant and to the database.
+     */
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public void createClaim(Claim claim) {
         Claimant claimant = claim.getClaimant();
         try {
             client.checkEligibility(claimant);
-        } catch (EligibilityClientException e) {
-            log.error("Unexpected exception caught trying to retrieve the Eligibility status from the Eligibility Service", e);
+        } catch (EligibilityClientException ece) {
+            log.error("Unexpected exception caught trying to determine the Eligibility status from the Eligibility Service", ece);
+        } catch (RuntimeException re) {
+            log.error("Unexpected exception caught trying to call the Eligibility Service", re);
         }
-        //TODO - Add eligibility status to the Claimant and to the database.
         claimantRepository.save(claimant);
         log.info("Saved new claimant: {}", claimant.getId());
     }

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/ClaimantToPersonDTOConverter.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/ClaimantToPersonDTOConverter.java
@@ -1,0 +1,32 @@
+package uk.gov.dhsc.htbhf.claimant.service;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+import uk.gov.dhsc.htbhf.claimant.entity.Address;
+import uk.gov.dhsc.htbhf.claimant.entity.Claimant;
+import uk.gov.dhsc.htbhf.claimant.model.AddressDTO;
+import uk.gov.dhsc.htbhf.claimant.model.eligibility.PersonDTO;
+
+@Component
+public class ClaimantToPersonDTOConverter implements Converter<Claimant, PersonDTO> {
+
+    @Override
+    public PersonDTO convert(Claimant claimant) {
+        return PersonDTO.builder()
+                .firstName(claimant.getFirstName())
+                .lastName(claimant.getLastName())
+                .dateOfBirth(claimant.getDateOfBirth())
+                .nino(claimant.getNino())
+                .address(convertAddress(claimant.getCardDeliveryAddress()))
+                .build();
+    }
+
+    private AddressDTO convertAddress(Address address) {
+        return AddressDTO.builder()
+                .addressLine1(address.getAddressLine1())
+                .addressLine2(address.getAddressLine2())
+                .townOrCity(address.getTownOrCity())
+                .postcode(address.getPostcode())
+                .build();
+    }
+}

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/EligibilityClient.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/EligibilityClient.java
@@ -37,7 +37,7 @@ public class EligibilityClient {
                 person,
                 EligibilityResponse.class
         );
-        if(HttpStatus.OK != response.getStatusCode()) {
+        if (HttpStatus.OK != response.getStatusCode()) {
             throw new EligibilityClientException(response.getStatusCode());
         }
         return response.getBody();

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/EligibilityClient.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/EligibilityClient.java
@@ -1,0 +1,41 @@
+package uk.gov.dhsc.htbhf.claimant.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.dhsc.htbhf.claimant.entity.Claimant;
+import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityResponse;
+import uk.gov.dhsc.htbhf.claimant.model.eligibility.PersonDTO;
+
+/**
+ * Client for calling the Eligibility Service using the RestTemplate defined in
+ * {@link uk.gov.dhsc.htbhf.requestcontext.RequestContextConfiguration}.
+ */
+@Component
+public class EligibilityClient {
+
+    public static final String ELIGIBILITY_ENDPOINT = "/v1/eligibility";
+    private final RestTemplate restTemplateWithIdHeaders;
+    private final ClaimantToPersonDTOConverter claimantToPersonDTOConverter;
+    private final String eligibilityUri;
+
+    public EligibilityClient(@Value("${eligibility.base-uri}") String baseUri,
+                             RestTemplate restTemplateWithIdHeaders,
+                             ClaimantToPersonDTOConverter claimantToPersonDTOConverter) {
+        this.eligibilityUri = baseUri + ELIGIBILITY_ENDPOINT;
+        this.restTemplateWithIdHeaders = restTemplateWithIdHeaders;
+        this.claimantToPersonDTOConverter = claimantToPersonDTOConverter;
+    }
+
+    public EligibilityResponse checkEligibility(Claimant claimant) {
+        PersonDTO person = claimantToPersonDTOConverter.convert(claimant);
+        ResponseEntity<EligibilityResponse> response = restTemplateWithIdHeaders.postForEntity(
+                eligibilityUri,
+                person,
+                EligibilityResponse.class
+        );
+        //TODO Log and throw an Exception if not a 200.
+        return response.getBody();
+    }
+}

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/EligibilityClient.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/EligibilityClient.java
@@ -1,10 +1,12 @@
 package uk.gov.dhsc.htbhf.claimant.service;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.dhsc.htbhf.claimant.entity.Claimant;
+import uk.gov.dhsc.htbhf.claimant.exception.EligibilityClientException;
 import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityResponse;
 import uk.gov.dhsc.htbhf.claimant.model.eligibility.PersonDTO;
 
@@ -35,7 +37,9 @@ public class EligibilityClient {
                 person,
                 EligibilityResponse.class
         );
-        //TODO Log and throw an Exception if not a 200.
+        if(HttpStatus.OK != response.getStatusCode()) {
+            throw new EligibilityClientException(response.getStatusCode());
+        }
         return response.getBody();
     }
 }

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
         name: claimant/api
     boot:
         admin:
-            url: http://localhost:8080
+            url: http://localhost:8090
     jackson:
       default-property-inclusion: NON_NULL
     flyway:

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -31,3 +31,6 @@ logging:
     level:
         ROOT: ${vcap.services.variable-service.credentials.claimant-root-loglevel:info}
         uk.gov.dhsc: ${vcap.services.variable-service.credentials.claimant-app-loglevel:debug}
+
+eligibility:
+    base-uri: ${ELIGIBILITY_URI:http://localhost:8100}

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -34,3 +34,6 @@ logging:
 
 eligibility:
     base-uri: ${ELIGIBILITY_URI:http://localhost:8100}
+
+server:
+    port: 8090

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/ClaimantServiceApplicationTests.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/ClaimantServiceApplicationTests.java
@@ -44,7 +44,7 @@ public class ClaimantServiceApplicationTests {
         assertThat(jsonAsYaml).containsSequence("swagger: \"2.0\"");
 
         File swaggerFile = new File("../swagger.yml");
-        Files.write(jsonAsYaml, swaggerFile, Charset.defaultCharset());
+        Files.asCharSink(swaggerFile, Charset.defaultCharset()).write(jsonAsYaml);
     }
 
     private String convertJsonToYaml(String response) throws IOException {

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/controller/ClaimControllerIntegrationTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/controller/ClaimControllerIntegrationTest.java
@@ -2,21 +2,41 @@ package uk.gov.dhsc.htbhf.claimant.controller;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
 import uk.gov.dhsc.htbhf.claimant.entity.Address;
 import uk.gov.dhsc.htbhf.claimant.entity.Claimant;
 import uk.gov.dhsc.htbhf.claimant.model.AddressDTO;
 import uk.gov.dhsc.htbhf.claimant.model.ClaimDTO;
+import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityResponse;
 import uk.gov.dhsc.htbhf.claimant.repository.ClaimantRepository;
 import uk.gov.dhsc.htbhf.claimant.testsupport.ClaimDTOTestDataFactory;
 
 import javax.transaction.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static uk.gov.dhsc.htbhf.claimant.service.EligibilityClient.ELIGIBILITY_ENDPOINT;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.EligibilityResponseTestDataFactory.anEligibilityResponse;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.PersonDTOTestDataFactory.aValidPerson;
 
 @SpringBootTest
 @Transactional
 public class ClaimControllerIntegrationTest {
+
+    @Value("${eligibility.base-uri}")
+    String baseUri;
+
+    @MockBean
+    RestTemplate restTemplateWithIdHeaders;
 
     @Autowired
     ClaimController controller;
@@ -28,6 +48,8 @@ public class ClaimControllerIntegrationTest {
     void shouldPersistNewClaimantWithoutOptionalFields() {
         // Given
         ClaimDTO claimDTO = ClaimDTOTestDataFactory.aValidClaimDTO();
+        ResponseEntity<EligibilityResponse> response = new ResponseEntity<>(anEligibilityResponse(), HttpStatus.OK);
+        given(restTemplateWithIdHeaders.postForEntity(anyString(), any(), eq(EligibilityResponse.class))).willReturn(response);
 
         // When
         controller.newClaim(claimDTO);
@@ -42,13 +64,15 @@ public class ClaimControllerIntegrationTest {
         assertThat(persistedClaim.getDateOfBirth()).isEqualTo(claimDTO.getClaimant().getDateOfBirth());
         assertThat(persistedClaim.getExpectedDeliveryDate()).isNull();
         assertAddressEqual(persistedClaim.getCardDeliveryAddress(), claimDTO.getClaimant().getCardDeliveryAddress());
-
+        verify(restTemplateWithIdHeaders).postForEntity(baseUri + ELIGIBILITY_ENDPOINT, aValidPerson(), EligibilityResponse.class);
     }
 
     @Test
     void shouldPersistNewClaimantWithAllFields() {
         // Given
         ClaimDTO claimDTO = ClaimDTOTestDataFactory.aValidClaimDTOWithNoNullFields();
+        ResponseEntity<EligibilityResponse> response = new ResponseEntity<>(anEligibilityResponse(), HttpStatus.OK);
+        given(restTemplateWithIdHeaders.postForEntity(anyString(), any(), eq(EligibilityResponse.class))).willReturn(response);
 
         // When
         controller.newClaim(claimDTO);
@@ -63,6 +87,7 @@ public class ClaimControllerIntegrationTest {
         assertThat(persistedClaim.getDateOfBirth()).isEqualTo(claimDTO.getClaimant().getDateOfBirth());
         assertThat(persistedClaim.getExpectedDeliveryDate()).isEqualTo(claimDTO.getClaimant().getExpectedDeliveryDate());
         assertAddressEqual(persistedClaim.getCardDeliveryAddress(), claimDTO.getClaimant().getCardDeliveryAddress());
+        verify(restTemplateWithIdHeaders).postForEntity(baseUri + ELIGIBILITY_ENDPOINT, aValidPerson(), EligibilityResponse.class);
     }
 
     private void assertAddressEqual(Address actual, AddressDTO expected) {

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/ClaimServiceTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/ClaimServiceTest.java
@@ -5,11 +5,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 import uk.gov.dhsc.htbhf.claimant.entity.Claim;
+import uk.gov.dhsc.htbhf.claimant.entity.Claimant;
+import uk.gov.dhsc.htbhf.claimant.exception.EligibilityClientException;
 import uk.gov.dhsc.htbhf.claimant.repository.ClaimantRepository;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimantTestDataFactory.aValidClaimant;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.EligibilityResponseTestDataFactory.anEligibilityResponse;
 
 @ExtendWith(MockitoExtension.class)
 public class ClaimServiceTest {
@@ -20,17 +26,41 @@ public class ClaimServiceTest {
     @Mock
     private ClaimantRepository claimantRepository;
 
+    @Mock
+    private EligibilityClient client;
+
     @Test
     public void shouldSaveClaimant() {
         //given
+        Claimant claimant = aValidClaimant();
         Claim claim = Claim.builder()
-                .claimant(aValidClaimant())
+                .claimant(claimant)
                 .build();
+        given(client.checkEligibility(any())).willReturn(anEligibilityResponse());
 
         //when
         claimService.createClaim(claim);
 
         //then
         verify(claimantRepository).save(claim.getClaimant());
+        verify(client).checkEligibility(claimant);
+    }
+
+    @Test
+    public void shouldNotSaveClaimantWhenEligibilityThrowsException() {
+        //given
+        Claimant claimant = aValidClaimant();
+        Claim claim = Claim.builder()
+                .claimant(claimant)
+                .build();
+        given(client.checkEligibility(any())).willThrow(new EligibilityClientException(HttpStatus.BAD_REQUEST));
+
+        //when
+        claimService.createClaim(claim);
+
+        //then
+        //TODO - Add verification to make sure that the status is added to the Claimant before persisting.
+        verify(claimantRepository).save(claim.getClaimant());
+        verify(client).checkEligibility(claimant);
     }
 }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/ClaimantToPersonDTOConverterTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/ClaimantToPersonDTOConverterTest.java
@@ -1,0 +1,36 @@
+package uk.gov.dhsc.htbhf.claimant.service;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.dhsc.htbhf.claimant.entity.Address;
+import uk.gov.dhsc.htbhf.claimant.entity.Claimant;
+import uk.gov.dhsc.htbhf.claimant.model.AddressDTO;
+import uk.gov.dhsc.htbhf.claimant.model.eligibility.PersonDTO;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimantTestDataFactory.aValidClaimant;
+
+class ClaimantToPersonDTOConverterTest {
+
+    private ClaimantToPersonDTOConverter converter = new ClaimantToPersonDTOConverter();
+
+    @Test
+    void shouldConvertValidClaimant() {
+        Claimant claimant = aValidClaimant();
+
+        PersonDTO person = converter.convert(claimant);
+
+        assertThat(person).isNotNull();
+        assertThat(person.getFirstName()).isEqualTo(claimant.getFirstName());
+        assertThat(person.getLastName()).isEqualTo(claimant.getLastName());
+        assertThat(person.getDateOfBirth()).isEqualTo(claimant.getDateOfBirth());
+        assertThat(person.getNino()).isEqualTo(claimant.getNino());
+        assertThat(person.getNino()).isEqualTo(claimant.getNino());
+        AddressDTO personAddress = person.getAddress();
+        assertThat(personAddress).isNotNull();
+        Address claimantAddress = claimant.getCardDeliveryAddress();
+        assertThat(personAddress.getAddressLine1()).isEqualTo(claimantAddress.getAddressLine1());
+        assertThat(personAddress.getAddressLine2()).isEqualTo(claimantAddress.getAddressLine2());
+        assertThat(personAddress.getTownOrCity()).isEqualTo(claimantAddress.getTownOrCity());
+        assertThat(personAddress.getPostcode()).isEqualTo(claimantAddress.getPostcode());
+    }
+}

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/EligibilityClientTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/EligibilityClientTest.java
@@ -1,0 +1,59 @@
+package uk.gov.dhsc.htbhf.claimant.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.dhsc.htbhf.claimant.entity.Claimant;
+import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityResponse;
+import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityStatus;
+import uk.gov.dhsc.htbhf.claimant.model.eligibility.PersonDTO;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
+import static uk.gov.dhsc.htbhf.claimant.service.EligibilityClient.ELIGIBILITY_ENDPOINT;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimantTestDataFactory.aValidClaimant;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.EligibilityResponseTestDataFactory.anEligibilityResponse;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.PersonDTOTestDataFactory.aValidPerson;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+class EligibilityClientTest {
+
+    @MockBean
+    private RestTemplate restTemplateWithIdHeaders;
+    @MockBean
+    private ClaimantToPersonDTOConverter claimantToPersonDTOConverter;
+    @Value("${eligibility.base-uri}")
+    private String baseUri;
+
+    @Autowired
+    private EligibilityClient client;
+
+    @Test
+    void shouldCheckEligibilitySuccessfully() {
+        Claimant claimant = aValidClaimant();
+        PersonDTO person = aValidPerson();
+        given(claimantToPersonDTOConverter.convert(any())).willReturn(person);
+        ResponseEntity<EligibilityResponse> response = new ResponseEntity<>(anEligibilityResponse(), HttpStatus.OK);
+        given(restTemplateWithIdHeaders.postForEntity(anyString(), any(), eq(EligibilityResponse.class)))
+                .willReturn(response);
+
+        EligibilityResponse eligibilityResponse = client.checkEligibility(claimant);
+
+        assertThat(eligibilityResponse).isNotNull();
+        assertThat(eligibilityResponse.getEligibilityStatus()).isEqualTo(EligibilityStatus.ELIGIBLE);
+        verify(claimantToPersonDTOConverter).convert(claimant);
+        verify(restTemplateWithIdHeaders).postForEntity(baseUri + ELIGIBILITY_ENDPOINT, person, EligibilityResponse.class);
+    }
+}

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/ClaimDTOTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/ClaimDTOTestDataFactory.java
@@ -10,7 +10,7 @@ import static java.time.LocalDate.now;
 
 public final class ClaimDTOTestDataFactory {
 
-    private static final String VALID_NINO = "QQ123456C";
+    private static final String VALID_NINO = "EB123456C";
     private static final String VALID_FIRST_NAME = "James";
     private static final String VALID_LAST_NAME = "Smith";
     private static final LocalDate VALID_DOB = LocalDate.parse("1985-12-31");

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/EligibilityResponseTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/EligibilityResponseTestDataFactory.java
@@ -1,0 +1,15 @@
+package uk.gov.dhsc.htbhf.claimant.testsupport;
+
+import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityResponse;
+
+import static uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityStatus.ELIGIBLE;
+
+public class EligibilityResponseTestDataFactory {
+
+    public static EligibilityResponse anEligibilityResponse() {
+        return EligibilityResponse.builder()
+                .eligibilityStatus(ELIGIBLE)
+                .build();
+    }
+
+}

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/PersonDTOTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/PersonDTOTestDataFactory.java
@@ -1,0 +1,40 @@
+package uk.gov.dhsc.htbhf.claimant.testsupport;
+
+import uk.gov.dhsc.htbhf.claimant.model.AddressDTO;
+import uk.gov.dhsc.htbhf.claimant.model.eligibility.PersonDTO;
+
+import java.time.LocalDate;
+
+public class PersonDTOTestDataFactory {
+
+    private static final LocalDate DOB = LocalDate.parse("1985-12-31");
+    private static final String ADDRESS_LINE_1 = "Flat b";
+    private static final String ADDRESS_LINE_2 = "123 Fake street";
+    private static final String TOWN_OR_CITY = "Springfield";
+    private static final String POSTCODE = "AA1 1AA";
+    private static final String NINO = "EB123456C";
+    private static final String FIRST_NAME = "Lisa";
+    private static final String LAST_NAME = "Simpson";
+
+    public static PersonDTO aValidPerson() {
+        return buildDefaultPerson().build();
+    }
+
+    private static PersonDTO.PersonDTOBuilder buildDefaultPerson() {
+        return PersonDTO.builder()
+                .dateOfBirth(DOB)
+                .nino(NINO)
+                .address(aValidAddress())
+                .firstName(FIRST_NAME)
+                .lastName(LAST_NAME);
+    }
+
+    private static AddressDTO aValidAddress() {
+        return AddressDTO.builder()
+                .addressLine1(ADDRESS_LINE_1)
+                .addressLine2(ADDRESS_LINE_2)
+                .townOrCity(TOWN_OR_CITY)
+                .postcode(POSTCODE)
+                .build();
+    }
+}

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/PersonDTOTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/PersonDTOTestDataFactory.java
@@ -13,8 +13,8 @@ public class PersonDTOTestDataFactory {
     private static final String TOWN_OR_CITY = "Springfield";
     private static final String POSTCODE = "AA1 1AA";
     private static final String NINO = "EB123456C";
-    private static final String FIRST_NAME = "Lisa";
-    private static final String LAST_NAME = "Simpson";
+    private static final String FIRST_NAME = "James";
+    private static final String LAST_NAME = "Smith";
 
     public static PersonDTO aValidPerson() {
         return buildDefaultPerson().build();

--- a/api/src/test/resources/application.yml
+++ b/api/src/test/resources/application.yml
@@ -1,3 +1,5 @@
 spring:
   datasource:
     url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+eligibility:
+  base-uri: http://localhost:8100

--- a/manifest.yml
+++ b/manifest.yml
@@ -10,6 +10,7 @@ applications:
   env:
     JBP_CONFIG_OPEN_JDK_JRE: '{jre: { version: 11.+ }}'
     APP_VERSION: ((app-version))
+    ELIGIBILITY_URI: http://htbhf-eligibility-service((app-suffix)).apps.internal:8080
   services:
     - htbhf-claimant-service-postgres
     - logit-ssl-drain

--- a/manifest.yml
+++ b/manifest.yml
@@ -10,7 +10,7 @@ applications:
   env:
     JBP_CONFIG_OPEN_JDK_JRE: '{jre: { version: 11.+ }}'
     APP_VERSION: ((app-version))
-    ELIGIBILITY_URI: http://htbhf-eligibility-service((app-suffix)).apps.internal:8080
+    ELIGIBILITY_URI: http://htbhf-eligibility-service((space-suffix)).apps.internal:8080
   services:
     - htbhf-claimant-service-postgres
     - logit-ssl-drain


### PR DESCRIPTION
Add in the call to the eligibility service. We have left this such that we still need to add the status on the claimant in the database, plus any failure in the call to the eligibility service has no impact on the saving of the Claimant so that we can add it in without it breaking the CD build (hopefully).