### PR TITLE
Feature/add status to claimant

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/entity/Claimant.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/entity/Claimant.java
@@ -6,12 +6,15 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityStatus;
 
 import java.time.LocalDate;
 import java.util.UUID;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
@@ -25,7 +28,7 @@ import javax.validation.constraints.Size;
  */
 @Entity
 @Data
-@Builder
+@Builder(toBuilder = true)
 @Table(name = "claimant")
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
@@ -61,6 +64,11 @@ public class Claimant {
     @NotNull
     @OneToOne(cascade = CascadeType.ALL)
     private Address cardDeliveryAddress;
+
+    @NotNull
+    @Column(name = "eligibility_status")
+    @Enumerated(EnumType.STRING)
+    private EligibilityStatus eligibilityStatus;
 
     /**
      * Adding a custom getter for the id so that we can compare a Claimant object before and after its initial

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/model/eligibility/EligibilityStatus.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/model/eligibility/EligibilityStatus.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 
 /**
  * The possible states that a claim can be in according to the DWP.
+ * The value of ERROR has been added for when there are problems connecting to DWP.
  */
 @AllArgsConstructor
 @JsonFormat(shape = JsonFormat.Shape.STRING)
@@ -13,5 +14,6 @@ public enum EligibilityStatus {
     ELIGIBLE,
     INELIGIBLE,
     PENDING,
-    NOMATCH
+    NOMATCH,
+    ERROR
 }

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/model/eligibility/EligibilityStatus.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/model/eligibility/EligibilityStatus.java
@@ -1,13 +1,10 @@
 package uk.gov.dhsc.htbhf.claimant.model.eligibility;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import lombok.AllArgsConstructor;
 
 /**
- * The possible states that a claim can be in according to the DWP.
- * The value of ERROR has been added for when there are problems connecting to DWP.
+ * The possible states that a claim can be in.
  */
-@AllArgsConstructor
 @JsonFormat(shape = JsonFormat.Shape.STRING)
 public enum EligibilityStatus {
 

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/ClaimService.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/ClaimService.java
@@ -12,6 +12,7 @@ import uk.gov.dhsc.htbhf.claimant.repository.ClaimantRepository;
 @Service
 @Slf4j
 @RequiredArgsConstructor
+@SuppressWarnings("PMD.DataflowAnomalyAnalysis") // PMD does not like reassignment of `eligibilityStatus`
 public class ClaimService {
 
     private final ClaimantRepository claimantRepository;
@@ -19,14 +20,13 @@ public class ClaimService {
 
     public void createClaim(Claim claim) {
         Claimant claimant = claim.getClaimant();
+        EligibilityStatus eligibilityStatus = EligibilityStatus.ERROR;
 
         try {
             EligibilityResponse eligibilityResponse = client.checkEligibility(claimant);
-            claimant.setEligibilityStatus(eligibilityResponse.getEligibilityStatus());
+            eligibilityStatus = eligibilityResponse.getEligibilityStatus();
         } finally {
-            if (claimant.getEligibilityStatus() == null) {
-                claimant.setEligibilityStatus(EligibilityStatus.ERROR);
-            }
+            claimant.setEligibilityStatus(eligibilityStatus);
             claimantRepository.save(claimant);
             log.info("Saved new claimant: {}", claimant.getId());
         }

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/ClaimService.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/ClaimService.java
@@ -5,6 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.dhsc.htbhf.claimant.entity.Claim;
 import uk.gov.dhsc.htbhf.claimant.entity.Claimant;
+import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityResponse;
+import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityStatus;
 import uk.gov.dhsc.htbhf.claimant.repository.ClaimantRepository;
 
 @Service
@@ -15,16 +17,16 @@ public class ClaimService {
     private final ClaimantRepository claimantRepository;
     private final EligibilityClient client;
 
-    /**
-     * NOTE: This is only here to keep Checkstyle happy - we'll remove as we resolve the TODOs.
-     * TODO - Add eligibility status to the Claimant and to the database. If EligibilityClientException caught, set
-     *        status to error on claimant. Ensure status is also logged.
-     */
     public void createClaim(Claim claim) {
         Claimant claimant = claim.getClaimant();
+
         try {
-            client.checkEligibility(claimant);
+            EligibilityResponse eligibilityResponse = client.checkEligibility(claimant);
+            claimant.setEligibilityStatus(eligibilityResponse.getEligibilityStatus());
         } finally {
+            if (claimant.getEligibilityStatus() == null) {
+                claimant.setEligibilityStatus(EligibilityStatus.ERROR);
+            }
             claimantRepository.save(claimant);
             log.info("Saved new claimant: {}", claimant.getId());
         }

--- a/api/src/test/groovy/uk/gov/dhsc/htbhf/claimant/controller/NewClaimSpec.groovy
+++ b/api/src/test/groovy/uk/gov/dhsc/htbhf/claimant/controller/NewClaimSpec.groovy
@@ -15,6 +15,7 @@ import uk.gov.dhsc.htbhf.claimant.entity.Address
 import uk.gov.dhsc.htbhf.claimant.model.AddressDTO
 import uk.gov.dhsc.htbhf.claimant.model.ClaimDTO
 import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityResponse
+import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityStatus
 import uk.gov.dhsc.htbhf.claimant.repository.ClaimantRepository
 
 import java.nio.CharBuffer
@@ -77,6 +78,7 @@ class NewClaimSpec extends Specification {
         assertThat(persistedClaim.lastName).isEqualTo(claim.claimant.lastName)
         assertThat(persistedClaim.dateOfBirth).isEqualTo(claim.claimant.dateOfBirth)
         assertThat(persistedClaim.expectedDeliveryDate).isEqualTo(claim.claimant.expectedDeliveryDate)
+        assertThat(persistedClaim.eligibilityStatus).isEqualTo(EligibilityStatus.ELIGIBLE)
         assertAddressEqual(persistedClaim.cardDeliveryAddress, claim.claimant.cardDeliveryAddress)
         verify(restTemplateWithIdHeaders).postForEntity("http://localhost:8100/v1/eligibility", aValidPerson(), EligibilityResponse.class) || true
     }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/controller/ClaimControllerIntegrationTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/controller/ClaimControllerIntegrationTest.java
@@ -13,6 +13,7 @@ import uk.gov.dhsc.htbhf.claimant.entity.Claimant;
 import uk.gov.dhsc.htbhf.claimant.model.AddressDTO;
 import uk.gov.dhsc.htbhf.claimant.model.ClaimDTO;
 import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityResponse;
+import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityStatus;
 import uk.gov.dhsc.htbhf.claimant.repository.ClaimantRepository;
 import uk.gov.dhsc.htbhf.claimant.testsupport.ClaimDTOTestDataFactory;
 
@@ -63,6 +64,7 @@ public class ClaimControllerIntegrationTest {
         assertThat(persistedClaim.getLastName()).isEqualTo(claimDTO.getClaimant().getLastName());
         assertThat(persistedClaim.getDateOfBirth()).isEqualTo(claimDTO.getClaimant().getDateOfBirth());
         assertThat(persistedClaim.getExpectedDeliveryDate()).isNull();
+        assertThat(persistedClaim.getEligibilityStatus()).isEqualTo(EligibilityStatus.ELIGIBLE);
         assertAddressEqual(persistedClaim.getCardDeliveryAddress(), claimDTO.getClaimant().getCardDeliveryAddress());
         verify(restTemplateWithIdHeaders).postForEntity(baseUri + ELIGIBILITY_ENDPOINT, aValidPerson(), EligibilityResponse.class);
     }
@@ -86,6 +88,7 @@ public class ClaimControllerIntegrationTest {
         assertThat(persistedClaim.getLastName()).isEqualTo(claimDTO.getClaimant().getLastName());
         assertThat(persistedClaim.getDateOfBirth()).isEqualTo(claimDTO.getClaimant().getDateOfBirth());
         assertThat(persistedClaim.getExpectedDeliveryDate()).isEqualTo(claimDTO.getClaimant().getExpectedDeliveryDate());
+        assertThat(persistedClaim.getEligibilityStatus()).isEqualTo(EligibilityStatus.ELIGIBLE);
         assertAddressEqual(persistedClaim.getCardDeliveryAddress(), claimDTO.getClaimant().getCardDeliveryAddress());
         verify(restTemplateWithIdHeaders).postForEntity(baseUri + ELIGIBILITY_ENDPOINT, aValidPerson(), EligibilityResponse.class);
     }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/entity/ClaimantTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/entity/ClaimantTest.java
@@ -21,7 +21,7 @@ class ClaimantTest extends AbstractValidationTest {
     @Test
     void shouldValidateClaimantSuccessfully() {
         //Given
-        Claimant claimant = ClaimantTestDataFactory.aValidClaimant();
+        Claimant claimant = ClaimantTestDataFactory.aValidClaimantWithEligibilityStatus();
         //When
         Set<ConstraintViolation<Claimant>> violations = validator.validate(claimant);
         //Then

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/repository/ClaimantRepositoryTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/repository/ClaimantRepositoryTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimantTestDataFactory.aClaimantWithLastName;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimantTestDataFactory.aClaimantWithTooLongFirstName;
-import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimantTestDataFactory.aValidClaimant;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimantTestDataFactory.aValidClaimantWithEligibilityStatus;
 
 @SpringBootTest
 class ClaimantRepositoryTest {
@@ -29,7 +29,7 @@ class ClaimantRepositoryTest {
     @Test
     void saveAndRetrieveClaimant() {
         //Given
-        Claimant claimant = aValidClaimant();
+        Claimant claimant = aValidClaimantWithEligibilityStatus();
 
         //When
         Claimant savedClaimant = claimantRepository.save(claimant);

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/ClaimantToPersonDTOConverterTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/ClaimantToPersonDTOConverterTest.java
@@ -7,7 +7,7 @@ import uk.gov.dhsc.htbhf.claimant.model.AddressDTO;
 import uk.gov.dhsc.htbhf.claimant.model.eligibility.PersonDTO;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimantTestDataFactory.aValidClaimant;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimantTestDataFactory.aClaimantWithoutEligibilityStatus;
 
 class ClaimantToPersonDTOConverterTest {
 
@@ -15,7 +15,7 @@ class ClaimantToPersonDTOConverterTest {
 
     @Test
     void shouldConvertValidClaimant() {
-        Claimant claimant = aValidClaimant();
+        Claimant claimant = aClaimantWithoutEligibilityStatus();
 
         PersonDTO person = converter.convert(claimant);
 

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/EligibilityClientTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/EligibilityClientTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 import static uk.gov.dhsc.htbhf.claimant.service.EligibilityClient.ELIGIBILITY_ENDPOINT;
-import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimantTestDataFactory.aValidClaimant;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimantTestDataFactory.aClaimantWithoutEligibilityStatus;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.EligibilityResponseTestDataFactory.anEligibilityResponse;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PersonDTOTestDataFactory.aValidPerson;
 
@@ -45,7 +45,7 @@ class EligibilityClientTest {
 
     @Test
     void shouldCheckEligibilitySuccessfully() {
-        Claimant claimant = aValidClaimant();
+        Claimant claimant = aClaimantWithoutEligibilityStatus();
         PersonDTO person = aValidPerson();
         given(claimantToPersonDTOConverter.convert(any())).willReturn(person);
         ResponseEntity<EligibilityResponse> response = new ResponseEntity<>(anEligibilityResponse(), HttpStatus.OK);
@@ -62,7 +62,7 @@ class EligibilityClientTest {
 
     @Test
     void shouldThrowAnExceptionWhenPostCallNotOk() {
-        Claimant claimant = aValidClaimant();
+        Claimant claimant = aClaimantWithoutEligibilityStatus();
         PersonDTO person = aValidPerson();
         given(claimantToPersonDTOConverter.convert(any())).willReturn(person);
         ResponseEntity<EligibilityResponse> response = new ResponseEntity<>(anEligibilityResponse(), HttpStatus.BAD_REQUEST);
@@ -79,7 +79,7 @@ class EligibilityClientTest {
 
     @Test
     void shouldThrowAnExceptionWhenPostCallReturnsError() {
-        Claimant claimant = aValidClaimant();
+        Claimant claimant = aClaimantWithoutEligibilityStatus();
         PersonDTO person = aValidPerson();
         given(claimantToPersonDTOConverter.convert(any())).willReturn(person);
         given(restTemplateWithIdHeaders.postForEntity(anyString(), any(), eq(EligibilityResponse.class)))

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/ClaimantTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/ClaimantTestDataFactory.java
@@ -2,6 +2,7 @@ package uk.gov.dhsc.htbhf.claimant.testsupport;
 
 import uk.gov.dhsc.htbhf.claimant.entity.Address;
 import uk.gov.dhsc.htbhf.claimant.entity.Claimant;
+import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityStatus;
 
 import java.nio.CharBuffer;
 import java.time.LocalDate;
@@ -18,7 +19,11 @@ public final class ClaimantTestDataFactory {
     private static final Address VALID_ADDRESS = AddressTestDataFactory.aValidAddress();
 
 
-    public static Claimant aValidClaimant() {
+    public static Claimant aClaimantWithoutEligibilityStatus() {
+        return aValidClaimantBuilder().eligibilityStatus(null).build();
+    }
+
+    public static Claimant aValidClaimantWithEligibilityStatus() {
         return aValidClaimantBuilder().build();
     }
 
@@ -56,6 +61,7 @@ public final class ClaimantTestDataFactory {
                 .lastName(VALID_LAST_NAME)
                 .nino(VALID_NINO)
                 .dateOfBirth(VALID_DOB)
-                .cardDeliveryAddress(VALID_ADDRESS);
+                .cardDeliveryAddress(VALID_ADDRESS)
+                .eligibilityStatus(EligibilityStatus.ELIGIBLE);
     }
 }

--- a/db/src/main/resources/db/migration/V1_002__add_status_column.sql
+++ b/db/src/main/resources/db/migration/V1_002__add_status_column.sql
@@ -1,5 +1,5 @@
 alter table claimant ADD COLUMN eligibility_status varchar(20);
 
-update claimant set eligibility_status = 'ELIGIBLE' where eligibility_status is null;
+update claimant set eligibility_status = 'INELIGIBLE' where eligibility_status is null;
 
 alter table claimant ALTER COLUMN eligibility_status SET not null;

--- a/db/src/main/resources/db/migration/V1_002__add_status_column.sql
+++ b/db/src/main/resources/db/migration/V1_002__add_status_column.sql
@@ -1,0 +1,5 @@
+alter table claimant ADD COLUMN eligibility_status varchar(20);
+
+update claimant set eligibility_status = 'ELIGIBLE' where eligibility_status is null;
+
+alter table claimant ALTER COLUMN eligibility_status SET not null;


### PR DESCRIPTION
- Persist claim eligibility status to database
- Set eligibility status to ERROR if error returned from eligibility status
- Update claimant test factory with distinct methods for claimant with / without eligibility status 