### PR TITLE
Fix IllegalArgumentException in compatibility tests

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/controller/ClaimController.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/controller/ClaimController.java
@@ -54,8 +54,17 @@ public class ClaimController {
 
     private ResponseEntity createResponseFromClaimant(Claimant claimant) {
         EligibilityStatus eligibilityStatus = claimant.getEligibilityStatus();
-        HttpStatus statusCode = statusMap.get(eligibilityStatus);
+        HttpStatus statusCode = getHttpStatus(eligibilityStatus);
         ClaimResponse body = ClaimResponse.builder().eligibilityStatus(eligibilityStatus).build();
         return new ResponseEntity(body, statusCode);
+    }
+
+    private HttpStatus getHttpStatus(EligibilityStatus eligibilityStatus) {
+        HttpStatus statusCode = statusMap.get(eligibilityStatus);
+        if (statusCode == null) {
+            log.warn("eligibility status without HttpStatus: {}", eligibilityStatus);
+            return HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+        return statusCode;
     }
 }

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/controller/ClaimController.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/controller/ClaimController.java
@@ -34,7 +34,11 @@ public class ClaimController {
     private final ClaimDTOToClaimConverter converter;
     private final Map<EligibilityStatus, HttpStatus> statusMap = Map.of(
             EligibilityStatus.ELIGIBLE, HttpStatus.CREATED,
-            EligibilityStatus.DUPLICATE, HttpStatus.OK
+            EligibilityStatus.INELIGIBLE, HttpStatus.OK,
+            EligibilityStatus.PENDING, HttpStatus.OK,
+            EligibilityStatus.NOMATCH, HttpStatus.OK,
+            EligibilityStatus.DUPLICATE, HttpStatus.OK,
+            EligibilityStatus.ERROR, HttpStatus.INTERNAL_SERVER_ERROR
     );
 
     @PostMapping

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/controller/ClaimControllerTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/controller/ClaimControllerTest.java
@@ -37,7 +37,11 @@ class ClaimControllerTest {
     @ParameterizedTest
     @CsvSource({
             "ELIGIBLE, CREATED",
-            "DUPLICATE, OK"
+            "INELIGIBLE, OK",
+            "PENDING, OK",
+            "NOMATCH, OK",
+            "DUPLICATE, OK",
+            "ERROR, INTERNAL_SERVER_ERROR"
     })
     void shouldInvokeClaimServiceWithConvertedClaim(EligibilityStatus eligibilityStatus, HttpStatus httpStatus) {
         // Given

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/controller/ClaimControllerTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/controller/ClaimControllerTest.java
@@ -1,5 +1,6 @@
 package uk.gov.dhsc.htbhf.claimant.controller;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -8,6 +9,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.dhsc.htbhf.claimant.converter.ClaimDTOToClaimConverter;
 import uk.gov.dhsc.htbhf.claimant.entity.Claim;
 import uk.gov.dhsc.htbhf.claimant.model.ClaimDTO;
@@ -15,9 +17,12 @@ import uk.gov.dhsc.htbhf.claimant.model.ClaimResponse;
 import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityStatus;
 import uk.gov.dhsc.htbhf.claimant.service.ClaimService;
 
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimDTOTestDataFactory.aValidClaimDTO;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimResponseTestDataFactory.aClaimResponseWithEligibilityStatus;
@@ -51,7 +56,7 @@ class ClaimControllerTest {
         given(claimService.createClaim(any())).willReturn(aValidClaimantWithStatus(eligibilityStatus));
 
         // When
-        ResponseEntity<ClaimResponse> response =  controller.newClaim(dto);
+        ResponseEntity<ClaimResponse> response = controller.newClaim(dto);
 
         // Then
         ClaimResponse claimResponse = aClaimResponseWithEligibilityStatus(eligibilityStatus);
@@ -62,4 +67,27 @@ class ClaimControllerTest {
         verify(claimService).createClaim(convertedClaim);
     }
 
+    @Test
+    void shouldReturnInternalServerErrorStatusWhenEligibilityStatusIsInvalid() {
+        // Given
+        Claim convertedClaim = Claim.builder().build();
+        given(converter.convert(any())).willReturn(convertedClaim);
+        given(claimService.createClaim(any())).willReturn(aValidClaimantWithStatus(EligibilityStatus.ELIGIBLE));
+        Map mockStatusMap = mock(Map.class);
+        ReflectionTestUtils.setField(controller, "statusMap", mockStatusMap);
+        given(mockStatusMap.get(EligibilityStatus.ELIGIBLE)).willReturn(null);
+        ClaimDTO dto = aValidClaimDTO();
+
+        // When
+        ResponseEntity<ClaimResponse> response = controller.newClaim(dto);
+
+        // Then
+        ClaimResponse claimResponse = aClaimResponseWithEligibilityStatus(EligibilityStatus.ELIGIBLE);
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.getBody()).isEqualTo(claimResponse);
+        verify(converter).convert(dto);
+        verify(claimService).createClaim(convertedClaim);
+        verify(mockStatusMap).get(EligibilityStatus.ELIGIBLE);
+    }
 }


### PR DESCRIPTION
The performance tests are creating responses from the eligibility service with a status of `NOMATCH` which need to be handled by the claimant service.

This PR ensures the claimant service handles all possible eligibility statuses.