### PR TITLE
HTBHF-947 Updated  javers to use random commit id to prevent id clash…

### DIFF
--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -38,6 +38,9 @@ logging:
     ROOT: ${vcap.services.variable-service.credentials.claimant-root-loglevel:info}
     uk.gov.dhsc: ${vcap.services.variable-service.credentials.claimant-app-loglevel:debug}
 
+javers:
+  commitIdGenerator: random
+
 eligibility:
   base-uri: ${ELIGIBILITY_URI:http://localhost:8100}
 


### PR DESCRIPTION
…es. These can occur under load with a distributed system.