### PR TITLE
HTBHF-1588 Add date of birth of children to the Claimant table and as…

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/converter/ClaimantDTOToClaimantConverter.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/converter/ClaimantDTOToClaimantConverter.java
@@ -28,6 +28,7 @@ public class ClaimantDTOToClaimantConverter {
                 .phoneNumber(claimant.getPhoneNumber())
                 .emailAddress(claimant.getEmailAddress())
                 .address(addressConverter.convert(claimant.getAddress()))
+                .childrenDob(claimant.getChildrenDob())
                 .build();
     }
 

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/entity/Claimant.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/entity/Claimant.java
@@ -1,10 +1,16 @@
 package uk.gov.dhsc.htbhf.claimant.entity;
 
 import lombok.*;
+import org.hibernate.annotations.Type;
+import uk.gov.dhsc.htbhf.claimant.model.constraint.ListOfDatesInPast;
 
 import java.time.LocalDate;
+import java.util.List;
 import javax.persistence.*;
-import javax.validation.constraints.*;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Past;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 
 import static uk.gov.dhsc.htbhf.claimant.model.Constants.VALID_EMAIL_REGEX;
 
@@ -59,4 +65,9 @@ public class Claimant extends VersionedEntity {
     @Size(max = 256)
     @Column(name = "email_address")
     private String emailAddress;
+
+    @Column(name = "children_dob_json")
+    @Type(type = "json")
+    @ListOfDatesInPast(message = "dates of birth of children should be all in the past")
+    private List<LocalDate> childrenDob;
 }

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/model/ClaimantDTO.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/model/ClaimantDTO.java
@@ -8,8 +8,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import uk.gov.dhsc.htbhf.claimant.model.constraint.DateWithinRelativeRange;
+import uk.gov.dhsc.htbhf.claimant.model.constraint.ListOfDatesInPast;
 
 import java.time.LocalDate;
+import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Past;
@@ -74,5 +76,10 @@ public class ClaimantDTO {
     @JsonProperty("emailAddress")
     @ApiModelProperty(notes = "The claimant's email address. e.g. test@email.com")
     private String emailAddress;
+
+    @JsonProperty("childrenDob")
+    @ApiModelProperty(notes = "The dates of birth of the claimant's children (if they have any)")
+    @ListOfDatesInPast(message = "dates of birth of children should be all in the past")
+    private List<LocalDate> childrenDob;
 
 }

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/model/constraint/ListOfDatesInPast.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/model/constraint/ListOfDatesInPast.java
@@ -1,0 +1,42 @@
+package uk.gov.dhsc.htbhf.claimant.model.constraint;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({FIELD, METHOD, PARAMETER, ANNOTATION_TYPE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = ListOfDatesInPastValidator.class)
+@Documented
+public @interface ListOfDatesInPast {
+
+    /**
+     * The message to use when this constraint is violated.
+     *
+     * @return The message to use when this constraint is violated
+     */
+    String message();
+
+    /**
+     * The validation groups to which this constraint belongs.
+     *
+     * @return The validation groups to which this constraint belongs
+     */
+    Class<?>[] groups() default {};
+
+    /**
+     * Payload can be used by clients of the Bean Validation API to assign custom payload objects to a constraint. This attribute is not used by the API itself.
+     *
+     * @return the custom payload
+     */
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/model/constraint/ListOfDatesInPastValidator.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/model/constraint/ListOfDatesInPastValidator.java
@@ -1,0 +1,30 @@
+package uk.gov.dhsc.htbhf.claimant.model.constraint;
+
+import org.springframework.util.CollectionUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class ListOfDatesInPastValidator implements ConstraintValidator<ListOfDatesInPast, List<LocalDate>> {
+
+    @Override
+    public boolean isValid(List<LocalDate> dates, ConstraintValidatorContext context) {
+        if (CollectionUtils.isEmpty(dates)) {
+            return true;
+        }
+        return allDatesInPast(dates);
+    }
+
+    private boolean allDatesInPast(List<LocalDate> dates) {
+        LocalDate now = LocalDate.now();
+
+        for (LocalDate date : dates) {
+            if (now.isBefore(date)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/converter/ClaimantDTOToClaimantConverterTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/converter/ClaimantDTOToClaimantConverterTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.AddressTestDataFactory.aValidAddress;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimantDTOTestDataFactory.aValidClaimantDTOWithNoNullFields;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.MAGGIE_DOB;
 
 @ExtendWith(MockitoExtension.class)
 class ClaimantDTOToClaimantConverterTest {
@@ -37,7 +38,6 @@ class ClaimantDTOToClaimantConverterTest {
 
         // Then
         assertThat(result).isNotNull();
-        assertThat(result).isNotNull();
         assertThat(result.getFirstName()).isEqualTo(claimantDTO.getFirstName());
         assertThat(result.getLastName()).isEqualTo(claimantDTO.getLastName());
         assertThat(result.getNino()).isEqualTo(claimantDTO.getNino());
@@ -46,6 +46,7 @@ class ClaimantDTOToClaimantConverterTest {
         assertThat(result.getAddress()).isEqualTo(ADDRESS);
         assertThat(result.getPhoneNumber()).isEqualTo(claimantDTO.getPhoneNumber());
         assertThat(result.getEmailAddress()).isEqualTo(claimantDTO.getEmailAddress());
+        assertThat(result.getChildrenDob()).containsExactly(MAGGIE_DOB);
         verify(addressConverter).convert(claimantDTO.getAddress());
     }
 

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/entity/ClaimantTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/entity/ClaimantTest.java
@@ -15,6 +15,7 @@ import javax.validation.ConstraintViolation;
 
 import static uk.gov.dhsc.htbhf.assertions.ConstraintViolationAssert.assertThat;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimantTestDataFactory.*;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.MAGGIE_DOB;
 
 class ClaimantTest extends AbstractValidationTest {
 
@@ -297,5 +298,26 @@ class ClaimantTest extends AbstractValidationTest {
         Set<ConstraintViolation<Claimant>> violations = validator.validate(claimant);
         //Then
         assertThat(violations).hasNoViolations();
+    }
+
+    @Test
+    void shouldValidateClaimantWithChildrenDob() {
+        //Given
+        Claimant claimant = aClaimantWithChildrenDob(MAGGIE_DOB);
+        //When
+        Set<ConstraintViolation<Claimant>> violations = validator.validate(claimant);
+        //Then
+        assertThat(violations).hasNoViolations();
+    }
+
+    @Test
+    void shouldFailToValidateClaimantWithChildrenDobInFuture() {
+        //Given
+        LocalDate futureDate = LocalDate.now().plusYears(1);
+        Claimant claimant = aClaimantWithChildrenDob(futureDate);
+        //When
+        Set<ConstraintViolation<Claimant>> violations = validator.validate(claimant);
+        //Then
+        assertThat(violations).hasSingleConstraintViolation("dates of birth of children should be all in the past", "childrenDob");
     }
 }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/MessageProcessorConfigurationTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/MessageProcessorConfigurationTest.java
@@ -47,6 +47,7 @@ class MessageProcessorConfigurationTest {
         //Given the application context is built using the TestConfig below
 
         //Then
+        @SuppressWarnings("unchecked")
         Map<MessageType, MessageTypeProcessor> allMessageProcessorsByType = (Map<MessageType, MessageTypeProcessor>)
                 ReflectionTestUtils.getField(messageProcessor, "messageProcessorsByType");
         assertThat(allMessageProcessorsByType).hasSize(2);

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/model/constraint/ListOfDatesInPastValidatorTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/model/constraint/ListOfDatesInPastValidatorTest.java
@@ -1,0 +1,70 @@
+package uk.gov.dhsc.htbhf.claimant.model.constraint;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ListOfDatesInPastValidatorTest {
+
+    private ListOfDatesInPastValidator validator = new ListOfDatesInPastValidator();
+
+    @Test
+    void shouldValidateEmptyList() {
+        //Given
+        List<LocalDate> dates = new ArrayList<>();
+        //When
+        boolean isValid = validator.isValid(dates, null);
+        //Then
+        assertThat(isValid).isTrue();
+    }
+
+    @Test
+    void shouldValidateNullList() {
+        //Given
+        List<LocalDate> dates = null;
+        //When
+        boolean isValid = validator.isValid(dates, null);
+        //Then
+        assertThat(isValid).isTrue();
+    }
+
+    @Test
+    void shouldValidateListWithDateInPast() {
+        //Given
+        LocalDate dateInPast = LocalDate.now().minusDays(1);
+        List<LocalDate> dates = Collections.singletonList(dateInPast);
+        //When
+        boolean isValid = validator.isValid(dates, null);
+        //Then
+        assertThat(isValid).isTrue();
+    }
+
+    @Test
+    void shouldNotValidateListWithDateInFuture() {
+        //Given
+        LocalDate dateInFuture = LocalDate.now().plusDays(1);
+        List<LocalDate> dates = Collections.singletonList(dateInFuture);
+        //When
+        boolean isValid = validator.isValid(dates, null);
+        //Then
+        assertThat(isValid).isFalse();
+    }
+
+    @Test
+    void shouldNotValidateListWithDateInFutureAndPast() {
+        //Given
+        LocalDate dateInFuture = LocalDate.now().plusDays(1);
+        LocalDate dateInPast = LocalDate.now().minusDays(1);
+        List<LocalDate> dates = List.of(dateInFuture, dateInPast);
+        //When
+        boolean isValid = validator.isValid(dates, null);
+        //Then
+        assertThat(isValid).isFalse();
+    }
+
+}

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/ClaimantDTOTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/ClaimantDTOTestDataFactory.java
@@ -4,6 +4,7 @@ import uk.gov.dhsc.htbhf.claimant.model.AddressDTO;
 import uk.gov.dhsc.htbhf.claimant.model.ClaimantDTO;
 
 import static java.time.LocalDate.now;
+import static java.util.Collections.singletonList;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.*;
 
 public class ClaimantDTOTestDataFactory {
@@ -11,6 +12,7 @@ public class ClaimantDTOTestDataFactory {
     public static ClaimantDTO aValidClaimantDTOWithNoNullFields() {
         return aValidClaimantBuilder()
                 .expectedDeliveryDate(now().plusMonths(4))
+                .childrenDob(singletonList(MAGGIE_DOB))
                 .build();
     }
 

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/ClaimantTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/ClaimantTestDataFactory.java
@@ -6,6 +6,7 @@ import uk.gov.dhsc.htbhf.claimant.entity.Claimant;
 import java.nio.CharBuffer;
 import java.time.LocalDate;
 
+import static java.util.Collections.singletonList;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.AddressTestDataFactory.aValidAddress;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.VALID_EMAIL_ADDRESS;
 
@@ -26,6 +27,10 @@ public final class ClaimantTestDataFactory {
 
     public static Claimant aClaimantWithLastName(String lastName) {
         return aValidClaimantBuilder().lastName(lastName).build();
+    }
+
+    public static Claimant aClaimantWithChildrenDob(LocalDate dateOfBirth) {
+        return aValidClaimantBuilder().childrenDob(singletonList(dateOfBirth)).build();
     }
 
     public static Claimant aClaimantWithExpectedDeliveryDate(LocalDate expectedDeliveryDate) {

--- a/db/src/main/resources/db/migration/V1_034__add_children_dob_to_claimant.sql
+++ b/db/src/main/resources/db/migration/V1_034__add_children_dob_to_claimant.sql
@@ -1,0 +1,1 @@
+alter table claimant ADD COLUMN children_dob_json json;

--- a/swagger.yml
+++ b/swagger.yml
@@ -142,6 +142,12 @@ definitions:
       address:
         description: "The address of the claimant"
         $ref: "#/definitions/AddressDTO"
+      childrenDob:
+        type: "array"
+        description: "The dates of birth of the claimant's children (if they have\
+          \ any)"
+        items:
+          $ref: "#/definitions/LocalDate"
       dateOfBirth:
         type: "string"
         format: "date"


### PR DESCRIPTION
… an optional request parameter for a new claim.

Only validation on the request is that if there are any dates provided, they all need to be in the past.