### PR TITLE
NO-JIRA Update Spring Boot version to fix Smoke Test build.

### DIFF
--- a/smoke_tests/build.gradle
+++ b/smoke_tests/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '2.1.2.RELEASE'
+        springBootVersion = '2.1.3.RELEASE'
         junitVersion = '5.3.2'
         jacksonVersion = '2.9.9'
     }


### PR DESCRIPTION
There was a problem with the 2.1.2-RELEASE version of Spring Boot in the Smoke Tests so upgrading to 2.1.3-RELEASE should trigger downloading and using this new version instead.