### PR TITLE
HTBHF-1777 Added back in pregnancy grace period and updated card max …

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/entitlement/PregnancyEntitlementCalculator.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/entitlement/PregnancyEntitlementCalculator.java
@@ -1,5 +1,6 @@
 package uk.gov.dhsc.htbhf.claimant.entitlement;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
@@ -14,8 +15,8 @@ public class PregnancyEntitlementCalculator {
 
     private final int pregnancyGracePeriodInWeeks;
 
-    public PregnancyEntitlementCalculator(PaymentCycleConfig paymentCycleConfig) {
-        this.pregnancyGracePeriodInWeeks = paymentCycleConfig.getWeeksAfterDueDate();
+    public PregnancyEntitlementCalculator(@Value("${entitlement.pregnancy-grace-period-in-weeks}") int pregnancyGracePeriodInWeeks) {
+        this.pregnancyGracePeriodInWeeks = pregnancyGracePeriodInWeeks;
     }
 
     public boolean isEntitledToVoucher(LocalDate dueDate, LocalDate entitlementDate) {

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -52,6 +52,7 @@ entitlement:
   number-of-vouchers-per-child-between-one-and-four: 1
   number-of-vouchers-per-pregnancy: 1
   voucher-value-in-pence: 310
+  pregnancy-grace-period-in-weeks: 12
 
 card:
   services-base-uri: ${CARD_SERVICES_URI:http://localhost:8140}
@@ -68,7 +69,7 @@ message-processor:
 payment-cycle:
   cycle-duration-in-days: 28
   number-of-calculation-periods: 4
-  maximum-balance-period: 8
+  maximum-balance-period: 16
   child-matched-to-pregnancy-period:
     weeks-before-due-date: 16
     weeks-after-due-date: 8

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/entitlement/CycleEntitlementCalculatorIntegrationTests.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/entitlement/CycleEntitlementCalculatorIntegrationTests.java
@@ -245,7 +245,7 @@ class CycleEntitlementCalculatorIntegrationTests {
     void shouldCalculateEntitlementWhenThereHasBeenNoChildNotifiedWithin8WeeksAfterExpectedDueDate() {
         VoucherEntitlement voucherEntitlement = VoucherEntitlement.builder().vouchersForPregnancy(4).build();
         PaymentCycleVoucherEntitlement previousEntitlement = new PaymentCycleVoucherEntitlement(singletonList(voucherEntitlement));
-        Optional<LocalDate> expectedDueDate = Optional.of(LocalDate.now().minusWeeks(8).minusDays(2));
+        Optional<LocalDate> expectedDueDate = Optional.of(LocalDate.now().minusWeeks(12).minusDays(2));
         List<LocalDate> childrenDatesOfBirth = emptyList();
 
         PaymentCycleVoucherEntitlement result =
@@ -261,10 +261,10 @@ class CycleEntitlementCalculatorIntegrationTests {
     }
 
     @Test
-    void shouldCalculateEntitlementWhenThereHasBeenNoChildNotifiedAndTheExpectedDueDateGoesOver8WeekThresholdWithinNextPaymentCycle() {
+    void shouldCalculateEntitlementWhenThereHasBeenNoChildNotifiedAndTheExpectedDueDateGoesOver12WeekThresholdWithinNextPaymentCycle() {
         VoucherEntitlement voucherEntitlement = VoucherEntitlement.builder().vouchersForPregnancy(4).build();
         PaymentCycleVoucherEntitlement previousEntitlement = new PaymentCycleVoucherEntitlement(singletonList(voucherEntitlement));
-        Optional<LocalDate> expectedDueDate = Optional.of(LocalDate.now().minusWeeks(6).minusDays(2));
+        Optional<LocalDate> expectedDueDate = Optional.of(LocalDate.now().minusWeeks(10).minusDays(2));
         List<LocalDate> childrenDatesOfBirth = emptyList();
 
         PaymentCycleVoucherEntitlement result =
@@ -280,10 +280,10 @@ class CycleEntitlementCalculatorIntegrationTests {
     }
 
     @Test
-    void shouldCalculateEntitlementWhenThereHasBeenNoChildNotifiedAndTheExpectedDueDateIsExactlyOn8WeekThresholdAtStartOfPaymentCycle() {
+    void shouldCalculateEntitlementWhenThereHasBeenNoChildNotifiedAndTheExpectedDueDateIsExactlyOn12WeekThresholdAtStartOfPaymentCycle() {
         VoucherEntitlement voucherEntitlement = VoucherEntitlement.builder().vouchersForPregnancy(4).build();
         PaymentCycleVoucherEntitlement previousEntitlement = new PaymentCycleVoucherEntitlement(singletonList(voucherEntitlement));
-        Optional<LocalDate> expectedDueDate = Optional.of(LocalDate.now().minusWeeks(8));
+        Optional<LocalDate> expectedDueDate = Optional.of(LocalDate.now().minusWeeks(12));
         List<LocalDate> childrenDatesOfBirth = emptyList();
 
         PaymentCycleVoucherEntitlement result =

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/entitlement/PregnancyEntitlementCalculatorTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/entitlement/PregnancyEntitlementCalculatorTest.java
@@ -9,19 +9,9 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
 class PregnancyEntitlementCalculatorTest {
 
-    private static final int WEEKS_BEFORE_DUE_DATE = 16;
-    private static final int PAYMENT_CYCLE_DURATION_IN_DAYS = 28;
-    private static final int PAYMENT_CYCLE_NO_CALCULATION_PERIODS = 4;
-    //This is the important values for these tests.
-    private static final int PREGNANCY_GRACE_PERIOD_IN_WEEKS = 8;
-    private static final PaymentCycleConfig CONFIG = new PaymentCycleConfig(
-            PAYMENT_CYCLE_DURATION_IN_DAYS,
-            PAYMENT_CYCLE_NO_CALCULATION_PERIODS,
-            WEEKS_BEFORE_DUE_DATE,
-            PREGNANCY_GRACE_PERIOD_IN_WEEKS
-    );
+    private static final int PREGNANCY_GRACE_PERIOD_IN_WEEKS = 12;
 
-    private PregnancyEntitlementCalculator calculator = new PregnancyEntitlementCalculator(CONFIG);
+    private PregnancyEntitlementCalculator calculator = new PregnancyEntitlementCalculator(PREGNANCY_GRACE_PERIOD_IN_WEEKS);
 
     @Test
     void shouldReturnTrueForDueDateInFuture() {

--- a/api/src/test/resources/application.yml
+++ b/api/src/test/resources/application.yml
@@ -23,6 +23,7 @@ entitlement:
   number-of-vouchers-per-child-between-one-and-four: 1
   number-of-vouchers-per-pregnancy: 1
   voucher-value-in-pence: 310
+  pregnancy-grace-period-in-weeks: 12
 
 card:
   services-base-uri: ${CARD_SERVICES_URI:http://localhost:8140}
@@ -39,7 +40,7 @@ message-processor:
 payment-cycle:
   cycle-duration-in-days: 28
   number-of-calculation-periods: 4
-  maximum-balance-period: 8
+  maximum-balance-period: 16
   child-matched-to-pregnancy-period:
     weeks-before-due-date: 16
     weeks-after-due-date: 8


### PR DESCRIPTION
- Updated max card balance to be sixteen weeks of first payment amount.
- Added back in a pregnancy grace period. The length of time we'll keep paying pregnancy vouchers after the due date when no new child has been matched to that pregnancy. Previously we were using the number of weeks in which a child's DOB is matched to a pregnancy.