### PR TITLE
HTBHF-1882 Create message context and payload for email messages, plus loading of context from payload.

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/EmailMessageConfiguration.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/EmailMessageConfiguration.java
@@ -1,0 +1,27 @@
+package uk.gov.dhsc.htbhf.claimant;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import uk.gov.dhsc.htbhf.claimant.message.payload.EmailType;
+
+import java.util.Map;
+
+@EnableConfigurationProperties
+@Configuration
+@ConfigurationProperties(prefix = "notify")
+@Getter
+@Setter
+public class EmailMessageConfiguration {
+
+    private Map<EmailType, String> templateIds;
+
+    @Bean
+    public EmailTemplateConfig emailTemplateConfig() {
+        return new EmailTemplateConfig(templateIds);
+    }
+
+}

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/EmailTemplateConfig.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/EmailTemplateConfig.java
@@ -1,0 +1,31 @@
+package uk.gov.dhsc.htbhf.claimant;
+
+import uk.gov.dhsc.htbhf.claimant.message.payload.EmailType;
+
+import java.util.Map;
+
+/**
+ * Contains all the mappings between email types and template ids. This is built on startup
+ * from configuration only.
+ */
+public class EmailTemplateConfig {
+
+    private final Map<EmailType, String> templateIds;
+
+    public EmailTemplateConfig(Map<EmailType, String> templateIds) {
+        this.templateIds = templateIds;
+    }
+
+    /**
+     * Get the templateId for the given email type.
+     *
+     * @param emailType The type of email to get the template id for
+     * @return The template id
+     */
+    public String getTemplateIdForEmail(EmailType emailType) {
+        if (!templateIds.containsKey(emailType)) {
+            throw new IllegalArgumentException("No template id defined for email type: " + emailType);
+        }
+        return templateIds.get(emailType);
+    }
+}

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/context/EmailMessageContext.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/context/EmailMessageContext.java
@@ -1,0 +1,15 @@
+package uk.gov.dhsc.htbhf.claimant.message.context;
+
+import lombok.Builder;
+import lombok.Data;
+import uk.gov.dhsc.htbhf.claimant.entity.Claim;
+
+import java.util.Map;
+
+@Data
+@Builder
+public class EmailMessageContext {
+    private Claim claim;
+    private String templateId;
+    private Map<String, Object> emailPersonalisation;
+}

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/payload/EmailMessagePayload.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/payload/EmailMessagePayload.java
@@ -1,0 +1,15 @@
+package uk.gov.dhsc.htbhf.claimant.message.payload;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Data
+@Builder
+public class EmailMessagePayload {
+    private UUID claimId;
+    private EmailType emailType;
+    private Map<String, Object> emailPersonalisation;
+}

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/payload/EmailType.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/payload/EmailType.java
@@ -1,0 +1,9 @@
+package uk.gov.dhsc.htbhf.claimant.message.payload;
+
+/**
+ * Enum containing all the types of email we currently have setup, each one should have a templateId setup in the config.
+ */
+public enum EmailType {
+    NEW_CARD,
+    PAYMENT
+}

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -96,3 +96,7 @@ management:
 postgres:
   service:
     id: "htbhf-claimant-service-postgres"
+
+notify:
+  templateIds:
+    NEW_CARD: bbbd8805-b020-41c9-b43f-c0e62318a6d5

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/EmailTemplateConfigTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/EmailTemplateConfigTest.java
@@ -1,0 +1,37 @@
+package uk.gov.dhsc.htbhf.claimant;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.dhsc.htbhf.claimant.message.payload.EmailType;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+class EmailTemplateConfigTest {
+
+    private static final String TEMPLATE_ID1 = "TemplateId1";
+    private static final Map<EmailType, String> TEMPLATE_IDS = Map.of(EmailType.NEW_CARD, TEMPLATE_ID1);
+    private EmailTemplateConfig emailTemplateConfig = new EmailTemplateConfig(TEMPLATE_IDS);
+
+    @Test
+    void shouldAddTemplateId() {
+        //Given
+        //When
+        String templateId = emailTemplateConfig.getTemplateIdForEmail(EmailType.NEW_CARD);
+        //Then
+        assertThat(templateId).isEqualTo(TEMPLATE_ID1);
+    }
+
+    @Test
+    void shouldFailToFindTemplateIdIfNotStored() {
+        //Given no templateIds stored
+        //When
+        IllegalArgumentException caught = catchThrowableOfType(
+                () -> emailTemplateConfig.getTemplateIdForEmail(EmailType.PAYMENT),
+                IllegalArgumentException.class);
+        //Then
+        assertThat(caught).hasMessage("No template id defined for email type: PAYMENT");
+    }
+
+}


### PR DESCRIPTION
 - Create payload and context objects for email message
 - Load `EmailMessageContext` from `EmailMessagePayload`
 - Added basic implementation of how the email message type -> templateId might be configured and stored to get the MessageContextLoader working.

I implemented the first (and simplest thing) that came to mind on how to configure the template ids by message type so we can reuse this for all future messages, so any alternate thoughts welcome. The idea is that we'd simple need to add a new value to the `EmailType` enum, a new config value in `application.yml` and then add to `EmailMessageConfiguration`. The last bit is a bit clunky, but I'm sure that will be iterated upon in the next PR or two.