### PR TITLE
HTBHF-1883 Build email payload values for a new card email.

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/EmailTemplateKey.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/EmailTemplateKey.java
@@ -1,0 +1,25 @@
+package uk.gov.dhsc.htbhf.claimant.message;
+
+/**
+ * Enum containing the keys that are used for parameterised values within Notify email templates.
+ */
+public enum EmailTemplateKey {
+
+    FIRST_NAME("First_name"),
+    LAST_NAME("Last_name"),
+    FIRST_PAYMENT_AMOUNT("first_payment_amount"),
+    PREGNANCY_PAYMENT("pregnancy_payment"),
+    CHILDREN_UNDER_1_PAYMENT("children_under_1_payment"),
+    CHILDREN_UNDER_4_PAYMENT("children_under_4_payment"),
+    NEXT_PAYMENT_DATE("next_payment_date");
+
+    private String templateKeyName;
+
+    EmailTemplateKey(String templateKeyName) {
+        this.templateKeyName = templateKeyName;
+    }
+
+    public String getTemplateKeyName() {
+        return templateKeyName;
+    }
+}

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/MessagePayloadFactory.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/MessagePayloadFactory.java
@@ -2,14 +2,24 @@ package uk.gov.dhsc.htbhf.claimant.message;
 
 import uk.gov.dhsc.htbhf.claimant.entitlement.PaymentCycleVoucherEntitlement;
 import uk.gov.dhsc.htbhf.claimant.entity.Claim;
+import uk.gov.dhsc.htbhf.claimant.entity.Claimant;
 import uk.gov.dhsc.htbhf.claimant.entity.PaymentCycle;
+import uk.gov.dhsc.htbhf.claimant.message.payload.EmailMessagePayload;
+import uk.gov.dhsc.htbhf.claimant.message.payload.EmailType;
 import uk.gov.dhsc.htbhf.claimant.message.payload.MakePaymentMessagePayload;
 import uk.gov.dhsc.htbhf.claimant.message.payload.NewCardRequestMessagePayload;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
+import static uk.gov.dhsc.htbhf.claimant.message.MoneyUtils.convertPenceToPounds;
 
 public class MessagePayloadFactory {
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("dd MMM yyyy");
 
     public static NewCardRequestMessagePayload buildNewCardMessagePayload(Claim claim,
                                                                           PaymentCycleVoucherEntitlement voucherEntitlement,
@@ -28,4 +38,63 @@ public class MessagePayloadFactory {
                 .cardAccountId(paymentCycle.getClaim().getCardAccountId())
                 .build();
     }
+
+    /**
+     * Builds the message payload required to send a new card email message. The email template has paremeterised values
+     * which are contained in the emailPersonalisation Map. All monetary amounts are formatted into pounds and the breakdown
+     * of voucher payments has been detailed in a bullet point list - any vouchers which are missing are replaced with a
+     * single blank line so that we don't have any empty bullet point in the email.
+     *
+     * @param paymentCycle The payment cycle with payment and voucher details.
+     * @return The constructed payload.
+     */
+    public static EmailMessagePayload buildSendNewCardSuccessEmailPayload(PaymentCycle paymentCycle) {
+        Claimant claimant = paymentCycle.getClaim().getClaimant();
+        PaymentCycleVoucherEntitlement voucherEntitlement = paymentCycle.getVoucherEntitlement();
+        Map<String, Object> emailPersonalisation = new HashMap<>();
+        emailPersonalisation.put(EmailTemplateKey.FIRST_NAME.getTemplateKeyName(), claimant.getFirstName());
+        emailPersonalisation.put(EmailTemplateKey.LAST_NAME.getTemplateKeyName(), claimant.getLastName());
+        emailPersonalisation.put(EmailTemplateKey.FIRST_PAYMENT_AMOUNT.getTemplateKeyName(),
+                convertPenceToPounds(paymentCycle.getTotalEntitlementAmountInPence()));
+        emailPersonalisation.put(EmailTemplateKey.PREGNANCY_PAYMENT.getTemplateKeyName(), buildPregnancyPaymentAmountSummary(voucherEntitlement));
+        emailPersonalisation.put(EmailTemplateKey.CHILDREN_UNDER_1_PAYMENT.getTemplateKeyName(), buildUnder1PaymentSummary(voucherEntitlement));
+        emailPersonalisation.put(EmailTemplateKey.CHILDREN_UNDER_4_PAYMENT.getTemplateKeyName(), buildUnder4PaymentSummary(voucherEntitlement));
+        String formattedCycleEndDate = paymentCycle.getCycleEndDate().format(DATE_FORMATTER);
+        emailPersonalisation.put(EmailTemplateKey.NEXT_PAYMENT_DATE.getTemplateKeyName(), formattedCycleEndDate);
+        return EmailMessagePayload.builder()
+                .claimId(paymentCycle.getClaim().getId())
+                .emailType(EmailType.NEW_CARD)
+                .emailPersonalisation(emailPersonalisation)
+                .build();
+    }
+
+    private static String buildPregnancyPaymentAmountSummary(PaymentCycleVoucherEntitlement voucherEntitlement) {
+        return formatPaymentAmountSummary(
+                "\\n* %s for a pregnancy",
+                voucherEntitlement.getVouchersForPregnancy(),
+                voucherEntitlement.getSingleVoucherValueInPence());
+    }
+
+    private static String buildUnder1PaymentSummary(PaymentCycleVoucherEntitlement voucherEntitlement) {
+        return formatPaymentAmountSummary(
+                "\\n* %s for children under 1",
+                voucherEntitlement.getVouchersForChildrenUnderOne(),
+                voucherEntitlement.getSingleVoucherValueInPence());
+    }
+
+    private static String buildUnder4PaymentSummary(PaymentCycleVoucherEntitlement voucherEntitlement) {
+        return formatPaymentAmountSummary(
+                "\\n* %s for children between 1 and 4",
+                voucherEntitlement.getVouchersForChildrenBetweenOneAndFour(),
+                voucherEntitlement.getSingleVoucherValueInPence());
+    }
+
+    private static String formatPaymentAmountSummary(String summaryTemplate, int numberOfVouchers, int voucherAmountInPence) {
+        if (numberOfVouchers == 0) {
+            return "";
+        }
+        int totalAmount = numberOfVouchers * voucherAmountInPence;
+        return String.format(summaryTemplate, convertPenceToPounds(totalAmount));
+    }
+
 }

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/MoneyUtils.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/MoneyUtils.java
@@ -1,0 +1,23 @@
+package uk.gov.dhsc.htbhf.claimant.message;
+
+import java.text.NumberFormat;
+import java.util.Locale;
+
+/**
+ * Contains utility methods for dealing with monetary amounts.
+ */
+public class MoneyUtils {
+
+    /**
+     * Given the amount in pence, convert it to an amount in pounds correctly formatted, e.g.
+     * 1298 will return a value of £12.98.
+     *
+     * @param amountInPence The amount in pence
+     * @return The formatted amount in pounds
+     */
+    public static String convertPenceToPounds(int amountInPence) {
+        NumberFormat numberFormat = NumberFormat.getCurrencyInstance(Locale.UK);
+        return numberFormat.format(amountInPence / 100.0);
+    }
+
+}

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/payload/EmailMessagePayload.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/payload/EmailMessagePayload.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 
 @Data
 @Builder
-public class EmailMessagePayload {
+public class EmailMessagePayload implements MessagePayload {
     private UUID claimId;
     private EmailType emailType;
     private Map<String, Object> emailPersonalisation;

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/MessagePayloadFactoryTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/MessagePayloadFactoryTest.java
@@ -4,18 +4,30 @@ import org.junit.jupiter.api.Test;
 import uk.gov.dhsc.htbhf.claimant.entitlement.PaymentCycleVoucherEntitlement;
 import uk.gov.dhsc.htbhf.claimant.entity.Claim;
 import uk.gov.dhsc.htbhf.claimant.entity.PaymentCycle;
+import uk.gov.dhsc.htbhf.claimant.message.payload.EmailMessagePayload;
+import uk.gov.dhsc.htbhf.claimant.message.payload.EmailType;
 import uk.gov.dhsc.htbhf.claimant.message.payload.MakePaymentMessagePayload;
 import uk.gov.dhsc.htbhf.claimant.message.payload.NewCardRequestMessagePayload;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimTestDataFactory.aValidClaim;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aValidPaymentCycle;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aValidPaymentCycleBuilder;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementWithFourWeeklyPregnancyVouchersOnly;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementWithFourWeeklyVouchers;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementWithVouchers;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.VALID_FIRST_NAME;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.VALID_LAST_NAME;
 
 class MessagePayloadFactoryTest {
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("dd MMM yyyy");
 
     @Test
     void shouldCreateNewCardMessagePayload() {
@@ -38,6 +50,64 @@ class MessagePayloadFactoryTest {
         assertThat(payload.getClaimId()).isEqualTo(paymentCycle.getClaim().getId());
         assertThat(payload.getPaymentCycleId()).isEqualTo(paymentCycle.getId());
         assertThat(payload.getCardAccountId()).isEqualTo(paymentCycle.getClaim().getCardAccountId());
+    }
+
+    @Test
+    void shouldBuildSendNewCardSuccessEmailPayloadWithAllPaymentTypes() {
+
+        LocalDate startDate = LocalDate.now();
+        LocalDate endDate = startDate.plusDays(28);
+        //TODO MRS 2019-07-25: This a realistic PaymentCycle with 4 weekly entitlements in it, change the default constructed PaymentCycle with entitlements
+        // so it is more realistic like this, plus remove those PaymentCycles that no longer make sense from the TestDataFactory.
+        PaymentCycle paymentCycle = aValidPaymentCycleBuilder()
+                .cycleStartDate(startDate)
+                .cycleEndDate(endDate)
+                .voucherEntitlement(aPaymentCycleVoucherEntitlementWithFourWeeklyVouchers())
+                .build();
+
+        EmailMessagePayload payload = MessagePayloadFactory.buildSendNewCardSuccessEmailPayload(paymentCycle);
+
+        assertThat(payload.getClaimId()).isEqualTo(paymentCycle.getClaim().getId());
+        assertThat(payload.getEmailType()).isEqualTo(EmailType.NEW_CARD);
+        Map<String, Object> emailPersonalisation = payload.getEmailPersonalisation();
+
+        assertThat(emailPersonalisation).containsOnly(
+                entry("First_name", VALID_FIRST_NAME),
+                entry("Last_name", VALID_LAST_NAME),
+                entry("first_payment_amount", "£49.60"),
+                entry("pregnancy_payment", "\\n* £12.40 for a pregnancy"),
+                entry("children_under_1_payment", "\\n* £24.80 for children under 1"),
+                entry("children_under_4_payment", "\\n* £12.40 for children between 1 and 4"),
+                entry("next_payment_date", DATE_FORMATTER.format(endDate))
+        );
+    }
+
+    @Test
+    void shouldBuildSendNewCardSuccessEmailPayloadWithOnlyPregnancyPayment() {
+        LocalDate startDate = LocalDate.now();
+        LocalDate endDate = startDate.plusDays(28);
+        PaymentCycle paymentCycle = aValidPaymentCycleBuilder()
+                .voucherEntitlement(aPaymentCycleVoucherEntitlementWithFourWeeklyPregnancyVouchersOnly())
+                .cycleStartDate(startDate)
+                .cycleEndDate(endDate)
+                .totalEntitlementAmountInPence(1240)
+                .build();
+
+        EmailMessagePayload payload = MessagePayloadFactory.buildSendNewCardSuccessEmailPayload(paymentCycle);
+
+        assertThat(payload.getClaimId()).isEqualTo(paymentCycle.getClaim().getId());
+        assertThat(payload.getEmailType()).isEqualTo(EmailType.NEW_CARD);
+        Map<String, Object> emailPersonalisation = payload.getEmailPersonalisation();
+
+        assertThat(emailPersonalisation).containsOnly(
+                entry("First_name", VALID_FIRST_NAME),
+                entry("Last_name", VALID_LAST_NAME),
+                entry("first_payment_amount", "£12.40"),
+                entry("pregnancy_payment", "\\n* £12.40 for a pregnancy"),
+                entry("children_under_1_payment", ""),
+                entry("children_under_4_payment", ""),
+                entry("next_payment_date", DATE_FORMATTER.format(endDate))
+        );
     }
 
 }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/MoneyUtilsTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/MoneyUtilsTest.java
@@ -1,0 +1,26 @@
+package uk.gov.dhsc.htbhf.claimant.message;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MoneyUtilsTest {
+
+    @ParameterizedTest
+    @CsvSource(
+            value = {
+                    "1234: £12.34",
+                    "5: £0.05",
+                    "0: £0.00",
+                    "78456789: £784,567.89",
+                    "1239876543: £12,398,765.43",
+                    "-572: -£5.72"
+            },
+            delimiter = ':'
+    )
+    void shouldConvertPenceToPounds(int amountInPence, String amountInPounds) {
+        assertThat(MoneyUtils.convertPenceToPounds(amountInPence)).isEqualTo(amountInPounds);
+    }
+
+}

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/payments/PaymentServiceTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/payments/PaymentServiceTest.java
@@ -9,7 +9,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import uk.gov.dhsc.htbhf.claimant.entity.*;
+import uk.gov.dhsc.htbhf.claimant.entity.Payment;
+import uk.gov.dhsc.htbhf.claimant.entity.PaymentCycle;
+import uk.gov.dhsc.htbhf.claimant.entity.PaymentStatus;
 import uk.gov.dhsc.htbhf.claimant.exception.EventFailedException;
 import uk.gov.dhsc.htbhf.claimant.model.card.CardBalanceResponse;
 import uk.gov.dhsc.htbhf.claimant.model.card.DepositFundsRequest;
@@ -170,7 +172,7 @@ class PaymentServiceTest {
     void shouldAuditFailedPaymentWhenInterimPaymentFails() {
         PaymentCycle paymentCycle = aValidPaymentCycle();
         RuntimeException testException = new RuntimeException("test exception");
-        int paymentAmountInPence = 310;
+        int paymentAmountInPence = 4960;
         given(cardClient.depositFundsToCard(any(), any())).willThrow(testException);
 
         EventFailedException exception = catchThrowableOfType(() -> paymentService.makeInterimPayment(paymentCycle, CARD_ACCOUNT_ID, paymentAmountInPence),

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/ClaimantTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/ClaimantTestDataFactory.java
@@ -8,18 +8,12 @@ import java.time.LocalDate;
 import java.util.Arrays;
 
 import static uk.gov.dhsc.htbhf.claimant.testsupport.AddressTestDataFactory.aValidAddress;
-import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.VALID_EMAIL_ADDRESS;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.*;
 
 public final class ClaimantTestDataFactory {
 
     // Create a string 501 characters long
     public static final String LONG_NAME = CharBuffer.allocate(501).toString().replace('\0', 'A');
-
-    private static final String VALID_NINO = "EB123456C";
-    private static final String VALID_FIRST_NAME = "James";
-    private static final String VALID_LAST_NAME = "Smith";
-    private static final LocalDate VALID_DOB = TestConstants.JAMES_DATE_OF_BIRTH;
-    private static final String VALID_PHONE_NUMBER = "+447700900128";
 
     public static Claimant aValidClaimant() {
         return aValidClaimantBuilder().build();

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/PaymentCycleTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/PaymentCycleTestDataFactory.java
@@ -16,7 +16,7 @@ import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlem
 public class PaymentCycleTestDataFactory {
 
     private static final int TOTAL_VOUCHERS = 1;
-    public static final int TOTAL_ENTITLEMENT_AMOUNT_IN_PENCE = 310;
+    public static final int TOTAL_ENTITLEMENT_AMOUNT_IN_PENCE = 4960;
 
 
     public static PaymentCycle aValidPaymentCycle() {

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/PaymentCycleVoucherEntitlementTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/PaymentCycleVoucherEntitlementTestDataFactory.java
@@ -44,6 +44,18 @@ public class PaymentCycleVoucherEntitlementTestDataFactory {
                 .build();
     }
 
+    public static PaymentCycleVoucherEntitlement aPaymentCycleVoucherEntitlementWithFourWeeklyPregnancyVouchersOnly() {
+        List<VoucherEntitlement> entitlements = List.of(
+                aVoucherEntitlementWithPregnancyVoucherOnlyForDate(LocalDate.now().minusWeeks(4)),
+                aVoucherEntitlementWithPregnancyVoucherOnlyForDate(LocalDate.now().minusWeeks(2)),
+                aVoucherEntitlementWithPregnancyVoucherOnlyForDate(LocalDate.now().minusWeeks(1)),
+                aVoucherEntitlementWithPregnancyVoucherOnlyForDate(LocalDate.now().minusWeeks(3))
+        );
+        return PaymentCycleVoucherEntitlement.builder()
+                .voucherEntitlements(entitlements)
+                .build();
+    }
+
     public static PaymentCycleVoucherEntitlement aPaymentCycleVoucherEntitlementWithZeroVouchers() {
         return aPaymentCycleVoucherEntitlementWithEntitlement(aVoucherEntitlementWithZeroVouchers());
     }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/TestConstants.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/TestConstants.java
@@ -28,7 +28,7 @@ public class TestConstants {
     public static final int TOTAL_VOUCHER_ENTITLEMENT = 4;
     public static final int TOTAL_VOUCHER_VALUE_IN_PENCE = 1240;
 
-    public static final LocalDate JAMES_DATE_OF_BIRTH = LocalDate.parse("1985-12-31");
+    public static final LocalDate JAMES_DATE_OF_BIRTH = VALID_DOB;
     public static final String JAMES_FIRST_NAME = "James";
     public static final String JAMES_LAST_NAME = "Smith";
 

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/VoucherEntitlementTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/VoucherEntitlementTestDataFactory.java
@@ -26,6 +26,16 @@ public class VoucherEntitlementTestDataFactory {
                 .build();
     }
 
+    public static VoucherEntitlement aVoucherEntitlementWithPregnancyVoucherOnlyForDate(LocalDate entitlementDate) {
+        return VoucherEntitlement.builder()
+                .singleVoucherValueInPence(VOUCHER_VALUE_IN_PENCE)
+                .vouchersForChildrenUnderOne(0)
+                .vouchersForChildrenBetweenOneAndFour(0)
+                .vouchersForPregnancy(1)
+                .entitlementDate(entitlementDate)
+                .build();
+    }
+
     public static VoucherEntitlement aVoucherEntitlementWithEntitlementDate(LocalDate entitlementDate) {
         return aVoucherEntitlementBuilder()
                 .entitlementDate(entitlementDate)


### PR DESCRIPTION
This PR only builds the payload of a new card success email, it isn't plumbed in anywhere yet. I had to modify the contents of some of the payment cycles and entitlements to make them more realistic.

There is a TODO to fix up the payment cycle entitlements that are built in the Test Data Factories and make them all more realistic, but I'll do this in another PR.