### PR TITLE
HTBHF-1883 Correct data setup in PaymentCycleVoucherEntitlementTestDataFactory…

### DIFF
--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/MessagePayloadFactoryTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/MessagePayloadFactoryTest.java
@@ -19,8 +19,7 @@ import static org.assertj.core.api.Assertions.entry;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimTestDataFactory.aValidClaim;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aValidPaymentCycle;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aValidPaymentCycleBuilder;
-import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementWithFourWeeklyPregnancyVouchersOnly;
-import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementWithFourWeeklyVouchers;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementWithPregnancyVouchers;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementWithVouchers;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.VALID_FIRST_NAME;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.VALID_LAST_NAME;
@@ -62,7 +61,7 @@ class MessagePayloadFactoryTest {
         PaymentCycle paymentCycle = aValidPaymentCycleBuilder()
                 .cycleStartDate(startDate)
                 .cycleEndDate(endDate)
-                .voucherEntitlement(aPaymentCycleVoucherEntitlementWithFourWeeklyVouchers())
+                .voucherEntitlement(aPaymentCycleVoucherEntitlementWithVouchers())
                 .build();
 
         EmailMessagePayload payload = MessagePayloadFactory.buildSendNewCardSuccessEmailPayload(paymentCycle);
@@ -87,7 +86,7 @@ class MessagePayloadFactoryTest {
         LocalDate startDate = LocalDate.now();
         LocalDate endDate = startDate.plusDays(28);
         PaymentCycle paymentCycle = aValidPaymentCycleBuilder()
-                .voucherEntitlement(aPaymentCycleVoucherEntitlementWithFourWeeklyPregnancyVouchersOnly())
+                .voucherEntitlement(aPaymentCycleVoucherEntitlementWithPregnancyVouchers())
                 .cycleStartDate(startDate)
                 .cycleEndDate(endDate)
                 .totalEntitlementAmountInPence(1240)

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/processor/DetermineEntitlementMessageProcessorTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/processor/DetermineEntitlementMessageProcessorTest.java
@@ -8,7 +8,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.dhsc.htbhf.claimant.entitlement.PaymentCycleVoucherEntitlement;
-import uk.gov.dhsc.htbhf.claimant.entitlement.VoucherEntitlement;
 import uk.gov.dhsc.htbhf.claimant.entity.Claim;
 import uk.gov.dhsc.htbhf.claimant.entity.Message;
 import uk.gov.dhsc.htbhf.claimant.entity.PaymentCycle;
@@ -39,8 +38,7 @@ import static uk.gov.dhsc.htbhf.claimant.testsupport.MessageContextTestDataFacto
 import static uk.gov.dhsc.htbhf.claimant.testsupport.MessageTestDataFactory.aValidMessageWithType;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aPaymentCycleWithCycleStartDateAndClaim;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aPaymentCycleWithCycleStartDateEntitlementAndClaim;
-import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementWithEntitlement;
-import static uk.gov.dhsc.htbhf.claimant.testsupport.VoucherEntitlementTestDataFactory.aVoucherEntitlementWithEntitlementDate;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementWithVouchers;
 import static uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus.ELIGIBLE;
 
 @ExtendWith(MockitoExtension.class)
@@ -122,8 +120,7 @@ class DetermineEntitlementMessageProcessorTest {
 
         //Previous payment cycle
         LocalDate previousCycleStartDate = LocalDate.now().minusWeeks(4);
-        VoucherEntitlement previousVoucherEntitlement = aVoucherEntitlementWithEntitlementDate(previousCycleStartDate);
-        PaymentCycleVoucherEntitlement previousPaymentCycleVoucherEntitlement = aPaymentCycleVoucherEntitlementWithEntitlement(previousVoucherEntitlement);
+        PaymentCycleVoucherEntitlement previousPaymentCycleVoucherEntitlement = aPaymentCycleVoucherEntitlementWithVouchers();
         PaymentCycle previousPaymentCycle = aPaymentCycleWithCycleStartDateEntitlementAndClaim(previousCycleStartDate,
                 previousPaymentCycleVoucherEntitlement,
                 claim);

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/payments/PaymentCalculatorTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/payments/PaymentCalculatorTest.java
@@ -7,13 +7,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.dhsc.htbhf.claimant.entity.PaymentCycleStatus.BALANCE_TOO_HIGH_FOR_PAYMENT;
 import static uk.gov.dhsc.htbhf.claimant.entity.PaymentCycleStatus.FULL_PAYMENT_MADE;
 import static uk.gov.dhsc.htbhf.claimant.entity.PaymentCycleStatus.PARTIAL_PAYMENT_MADE;
-import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementWithFourWeeklyVouchers;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementWithVouchers;
 
 class PaymentCalculatorTest {
 
     private static final int MAXIMUM_BALANCE_PERIOD = 8;
     private PaymentCalculator paymentCalculator = new PaymentCalculator(MAXIMUM_BALANCE_PERIOD);
-    private static final PaymentCycleVoucherEntitlement ENTITLEMENT = aPaymentCycleVoucherEntitlementWithFourWeeklyVouchers();
+    private static final PaymentCycleVoucherEntitlement ENTITLEMENT = aPaymentCycleVoucherEntitlementWithVouchers();
     private static final int MAXIMUM_BALANCE = 9920;
     private static final int PAYMENT_CYCLE_ENTITLEMENT_AMOUNT = 4960;
 

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/PaymentCycleVoucherEntitlementTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/PaymentCycleVoucherEntitlementTestDataFactory.java
@@ -1,73 +1,70 @@
 package uk.gov.dhsc.htbhf.claimant.testsupport;
 
 import uk.gov.dhsc.htbhf.claimant.entitlement.PaymentCycleVoucherEntitlement;
-import uk.gov.dhsc.htbhf.claimant.entitlement.VoucherEntitlement;
 
 import java.time.LocalDate;
 import java.util.List;
 
-import static java.util.Collections.singletonList;
-import static uk.gov.dhsc.htbhf.claimant.testsupport.VoucherEntitlementTestDataFactory.*;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.VoucherEntitlementTestDataFactory.aVoucherEntitlementWithEntitlementDate;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.VoucherEntitlementTestDataFactory.aVoucherEntitlementWithNoPregnancyVouchers;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.VoucherEntitlementTestDataFactory.aVoucherEntitlementWithPregnancyVoucherOnlyForDate;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.VoucherEntitlementTestDataFactory.aVoucherEntitlementWithZeroVouchers;
 
 public class PaymentCycleVoucherEntitlementTestDataFactory {
-
-    public static PaymentCycleVoucherEntitlement aPaymentCycleVoucherEntitlementWithPregnancyVouchers() {
-        return buildDefaultPaymentCycleVoucherEntitlement()
-                .voucherEntitlements(singletonList(
-                        aVoucherEntitlementWithPregnancyVouchers(4)
-                ))
-                .build();
-    }
-
-    public static PaymentCycleVoucherEntitlement aPaymentCycleVoucherEntitlementWithoutPregnancyVouchers() {
-        return buildDefaultPaymentCycleVoucherEntitlement()
-                .voucherEntitlements(singletonList(
-                        aVoucherEntitlementWithPregnancyVouchers(0)
-                ))
-                .build();
-    }
 
     public static PaymentCycleVoucherEntitlement aPaymentCycleVoucherEntitlementWithVouchers() {
         return buildDefaultPaymentCycleVoucherEntitlement()
                 .build();
     }
 
-    public static PaymentCycleVoucherEntitlement aPaymentCycleVoucherEntitlementWithFourWeeklyVouchers() {
-        List<VoucherEntitlement> entitlements = List.of(
-                aVoucherEntitlementWithEntitlementDate(LocalDate.now().minusWeeks(4)),
-                aVoucherEntitlementWithEntitlementDate(LocalDate.now().minusWeeks(2)),
-                aVoucherEntitlementWithEntitlementDate(LocalDate.now().minusWeeks(1)),
-                aVoucherEntitlementWithEntitlementDate(LocalDate.now().minusWeeks(3))
-        );
+    public static PaymentCycleVoucherEntitlement aPaymentCycleVoucherEntitlementWithPregnancyVouchers() {
         return PaymentCycleVoucherEntitlement.builder()
-                .voucherEntitlements(entitlements)
+                .voucherEntitlements(
+                        List.of(
+                                aVoucherEntitlementWithPregnancyVoucherOnlyForDate(LocalDate.now().minusWeeks(1)),
+                                aVoucherEntitlementWithPregnancyVoucherOnlyForDate(LocalDate.now().minusWeeks(2)),
+                                aVoucherEntitlementWithPregnancyVoucherOnlyForDate(LocalDate.now().minusWeeks(3)),
+                                aVoucherEntitlementWithPregnancyVoucherOnlyForDate(LocalDate.now().minusWeeks(4))
+                        )
+                )
                 .build();
     }
 
-    public static PaymentCycleVoucherEntitlement aPaymentCycleVoucherEntitlementWithFourWeeklyPregnancyVouchersOnly() {
-        List<VoucherEntitlement> entitlements = List.of(
-                aVoucherEntitlementWithPregnancyVoucherOnlyForDate(LocalDate.now().minusWeeks(4)),
-                aVoucherEntitlementWithPregnancyVoucherOnlyForDate(LocalDate.now().minusWeeks(2)),
-                aVoucherEntitlementWithPregnancyVoucherOnlyForDate(LocalDate.now().minusWeeks(1)),
-                aVoucherEntitlementWithPregnancyVoucherOnlyForDate(LocalDate.now().minusWeeks(3))
-        );
-        return PaymentCycleVoucherEntitlement.builder()
-                .voucherEntitlements(entitlements)
+    public static PaymentCycleVoucherEntitlement aPaymentCycleVoucherEntitlementWithoutPregnancyVouchers() {
+        return buildDefaultPaymentCycleVoucherEntitlement()
+                .voucherEntitlements(
+                        List.of(
+                                aVoucherEntitlementWithNoPregnancyVouchers(LocalDate.now().minusWeeks(1)),
+                                aVoucherEntitlementWithNoPregnancyVouchers(LocalDate.now().minusWeeks(2)),
+                                aVoucherEntitlementWithNoPregnancyVouchers(LocalDate.now().minusWeeks(3)),
+                                aVoucherEntitlementWithNoPregnancyVouchers(LocalDate.now().minusWeeks(4))
+                        )
+                )
                 .build();
     }
 
     public static PaymentCycleVoucherEntitlement aPaymentCycleVoucherEntitlementWithZeroVouchers() {
-        return aPaymentCycleVoucherEntitlementWithEntitlement(aVoucherEntitlementWithZeroVouchers());
-    }
-
-    public static PaymentCycleVoucherEntitlement aPaymentCycleVoucherEntitlementWithEntitlement(VoucherEntitlement voucherEntitlement) {
         return buildDefaultPaymentCycleVoucherEntitlement()
-                .voucherEntitlements(singletonList(voucherEntitlement))
+                .voucherEntitlements(
+                        List.of(
+                                aVoucherEntitlementWithZeroVouchers(LocalDate.now().minusWeeks(1)),
+                                aVoucherEntitlementWithZeroVouchers(LocalDate.now().minusWeeks(2)),
+                                aVoucherEntitlementWithZeroVouchers(LocalDate.now().minusWeeks(3)),
+                                aVoucherEntitlementWithZeroVouchers(LocalDate.now().minusWeeks(4))
+                        )
+                )
                 .build();
     }
 
     private static PaymentCycleVoucherEntitlement.PaymentCycleVoucherEntitlementBuilder buildDefaultPaymentCycleVoucherEntitlement() {
         return PaymentCycleVoucherEntitlement.builder()
-                .voucherEntitlements(singletonList(aValidVoucherEntitlement()));
+                .voucherEntitlements(
+                        List.of(
+                                aVoucherEntitlementWithEntitlementDate(LocalDate.now().minusWeeks(1)),
+                                aVoucherEntitlementWithEntitlementDate(LocalDate.now().minusWeeks(2)),
+                                aVoucherEntitlementWithEntitlementDate(LocalDate.now().minusWeeks(3)),
+                                aVoucherEntitlementWithEntitlementDate(LocalDate.now().minusWeeks(4))
+                        )
+                );
     }
 }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/VoucherEntitlementTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/VoucherEntitlementTestDataFactory.java
@@ -16,13 +16,13 @@ public class VoucherEntitlementTestDataFactory {
                 .build();
     }
 
-    public static VoucherEntitlement aVoucherEntitlementWithZeroVouchers() {
+    public static VoucherEntitlement aVoucherEntitlementWithZeroVouchers(LocalDate entitlementDate) {
         return VoucherEntitlement.builder()
                 .singleVoucherValueInPence(VOUCHER_VALUE_IN_PENCE)
                 .vouchersForChildrenUnderOne(0)
                 .vouchersForChildrenBetweenOneAndFour(0)
                 .vouchersForPregnancy(0)
-                .entitlementDate(LocalDate.now())
+                .entitlementDate(entitlementDate)
                 .build();
     }
 
@@ -42,9 +42,10 @@ public class VoucherEntitlementTestDataFactory {
                 .build();
     }
 
-    public static VoucherEntitlement aVoucherEntitlementWithPregnancyVouchers(Integer vouchersForPregnancy) {
+    public static VoucherEntitlement aVoucherEntitlementWithNoPregnancyVouchers(LocalDate entitlementDate) {
         return aVoucherEntitlementBuilder()
-                .vouchersForPregnancy(vouchersForPregnancy)
+                .vouchersForPregnancy(0)
+                .entitlementDate(entitlementDate)
                 .build();
     }
 


### PR DESCRIPTION
… so that each PaymentCycleVoucherEntitlement that is created is actually representative of a real payment cycle, in that we'll have 4 vouch entitlements each a week apart.

The next PR will then focus on the PaymentCycleTestDataFactory and make sure that the vouchers and values created are correct according to the vouchers that are contained within.