### PR TITLE
HTBHF-2171 Increased the timeout for the initial healthcheck from 1 to 3 minutes

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -5,6 +5,7 @@ applications:
   - java_buildpack
   health-check-type: http
   health-check-http-endpoint: /actuator/health
+  health-check-timeout: 180
   routes:
     - route: htbhf-claimant-service((app-suffix)).apps.internal
   env:


### PR DESCRIPTION
Increases the timeout for the first healthcheck (after startup) - the normal healthcheck is unchanged.