### PR TITLE
HTBHF-2319 Create NextPaymentCycleSummary to store summary information…

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/processor/MakePaymentMessageProcessor.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/processor/MakePaymentMessageProcessor.java
@@ -48,16 +48,17 @@ public class MakePaymentMessageProcessor implements MessageTypeProcessor {
         paymentService.makePaymentForCycle(paymentCycle, messageContext.getCardAccountId());
         EmailMessagePayload messagePayload = buildPaymentNotificationEmailPayload(paymentCycle);
         messageQueueClient.sendMessage(messagePayload, MessageType.SEND_EMAIL);
-        int numChildrenTurningFourInNextMonth = childDateOfBirthCalculator.getNumberOfChildrenTurningFourAffectingNextPayment(paymentCycle);
-        if (numChildrenTurningFourInNextMonth > 0) {
-            sendChildTurnsFourEmail(paymentCycle, numChildrenTurningFourInNextMonth);
+        NextPaymentCycleSummary dateOfBirthSummaryAffectingNextPayment =
+                childDateOfBirthCalculator.getChildrenDateOfBirthSummaryAffectingNextPayment(paymentCycle);
+        if (dateOfBirthSummaryAffectingNextPayment.hasChildrenTurningFour()) {
+            sendChildTurnsFourEmail(paymentCycle, dateOfBirthSummaryAffectingNextPayment);
         }
         return COMPLETED;
     }
 
-    private void sendChildTurnsFourEmail(PaymentCycle paymentCycle, int numChildrenTurningFourInNextMonth) {
+    private void sendChildTurnsFourEmail(PaymentCycle paymentCycle, NextPaymentCycleSummary dateOfBirthSummaryAffectingNextPayment) {
         PaymentCycleVoucherEntitlement entitlement = determineEntitlementForNextCycle(paymentCycle);
-        boolean multipleChildrenTurningFourInNextMonth = numChildrenTurningFourInNextMonth > 1;
+        boolean multipleChildrenTurningFourInNextMonth = dateOfBirthSummaryAffectingNextPayment.hasMultipleChildrenTurningFour();
         EmailMessagePayload messagePayload = buildChildTurnsFourNotificationEmailPayload(
                 paymentCycle,
                 entitlement,

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/processor/NextPaymentCycleSummary.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/processor/NextPaymentCycleSummary.java
@@ -1,0 +1,33 @@
+package uk.gov.dhsc.htbhf.claimant.message.processor;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * A summary of factors that can affect the next payment cycle.
+ */
+@Data
+@Builder
+public class NextPaymentCycleSummary {
+
+    public static final NextPaymentCycleSummary NO_CHILDREN = NextPaymentCycleSummary.builder().build();
+
+    private int numberOfChildrenTurningOne;
+    private int numberOfChildrenTurningFour;
+
+    public boolean hasChildrenTurningFour() {
+        return numberOfChildrenTurningFour > 0;
+    }
+
+    public boolean hasMultipleChildrenTurningFour() {
+        return numberOfChildrenTurningFour > 1;
+    }
+
+    public boolean hasChildrenTurningOne() {
+        return numberOfChildrenTurningOne > 0;
+    }
+
+    public boolean hasMultipleChildrenTurningOne() {
+        return numberOfChildrenTurningOne > 1;
+    }
+}

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/processor/ChildDateOfBirthCalculatorTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/processor/ChildDateOfBirthCalculatorTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.lenient;
+import static uk.gov.dhsc.htbhf.claimant.message.processor.NextPaymentCycleSummary.NO_CHILDREN;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aPaymentCycleWithPregnancyVouchersOnly;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aValidPaymentCycleBuilder;
 
@@ -59,9 +60,9 @@ class ChildDateOfBirthCalculatorTest {
                 ELDEST_CHILD_DOB
         );
         //When
-        int numChildrenTurningFour = childDateOfBirthCalculator.getNumberOfChildrenTurningFourAffectingNextPayment(paymentCycle);
+        NextPaymentCycleSummary summary = childDateOfBirthCalculator.getChildrenDateOfBirthSummaryAffectingNextPayment(paymentCycle);
         //Then
-        assertThat(numChildrenTurningFour).isEqualTo(0);
+        assertThat(summary).isEqualTo(NO_CHILDREN);
     }
 
     @Test
@@ -72,9 +73,10 @@ class ChildDateOfBirthCalculatorTest {
                 DOB_TURNS_FOUR_IN_NEXT_PAYMENT_CYCLE
         );
         //When
-        int numChildrenTurningFour = childDateOfBirthCalculator.getNumberOfChildrenTurningFourAffectingNextPayment(paymentCycle);
+        NextPaymentCycleSummary summary = childDateOfBirthCalculator.getChildrenDateOfBirthSummaryAffectingNextPayment(paymentCycle);
         //Then
-        assertThat(numChildrenTurningFour).isEqualTo(1);
+        NextPaymentCycleSummary expectedSummary = NextPaymentCycleSummary.builder().numberOfChildrenTurningFour(1).build();
+        assertThat(summary).isEqualTo(expectedSummary);
     }
 
     @Test
@@ -85,9 +87,10 @@ class ChildDateOfBirthCalculatorTest {
                 NEXT_CYCLE_FINAL_ENTITLEMENT_DATE.minusYears(4)
         );
         //When
-        int numChildrenTurningFour = childDateOfBirthCalculator.getNumberOfChildrenTurningFourAffectingNextPayment(paymentCycle);
+        NextPaymentCycleSummary summary = childDateOfBirthCalculator.getChildrenDateOfBirthSummaryAffectingNextPayment(paymentCycle);
         //Then
-        assertThat(numChildrenTurningFour).isEqualTo(1);
+        NextPaymentCycleSummary expectedSummary = NextPaymentCycleSummary.builder().numberOfChildrenTurningFour(1).build();
+        assertThat(summary).isEqualTo(expectedSummary);
     }
 
     @Test
@@ -98,9 +101,9 @@ class ChildDateOfBirthCalculatorTest {
                 NEXT_CYCLE_FINAL_ENTITLEMENT_DATE.minusYears(4).plusDays(1)
         );
         //When
-        int numChildrenTurningFour = childDateOfBirthCalculator.getNumberOfChildrenTurningFourAffectingNextPayment(paymentCycle);
+        NextPaymentCycleSummary summary = childDateOfBirthCalculator.getChildrenDateOfBirthSummaryAffectingNextPayment(paymentCycle);
         //Then
-        assertThat(numChildrenTurningFour).isEqualTo(0);
+        assertThat(summary).isEqualTo(NO_CHILDREN);
     }
 
     @Test
@@ -111,9 +114,9 @@ class ChildDateOfBirthCalculatorTest {
                 CURRENT_CYCLE_FINAL_ENTITLEMENT_DATE.minusYears(4)
         );
         //When
-        int numChildrenTurningFour = childDateOfBirthCalculator.getNumberOfChildrenTurningFourAffectingNextPayment(paymentCycle);
+        NextPaymentCycleSummary summary = childDateOfBirthCalculator.getChildrenDateOfBirthSummaryAffectingNextPayment(paymentCycle);
         //Then
-        assertThat(numChildrenTurningFour).isEqualTo(0);
+        assertThat(summary).isEqualTo(NO_CHILDREN);
     }
 
     @Test
@@ -124,9 +127,10 @@ class ChildDateOfBirthCalculatorTest {
                 CURRENT_CYCLE_FINAL_ENTITLEMENT_DATE.minusYears(4).plusDays(1)
         );
         //When
-        int numChildrenTurningFour = childDateOfBirthCalculator.getNumberOfChildrenTurningFourAffectingNextPayment(paymentCycle);
+        NextPaymentCycleSummary summary = childDateOfBirthCalculator.getChildrenDateOfBirthSummaryAffectingNextPayment(paymentCycle);
         //Then
-        assertThat(numChildrenTurningFour).isEqualTo(1);
+        NextPaymentCycleSummary expectedSummary = NextPaymentCycleSummary.builder().numberOfChildrenTurningFour(1).build();
+        assertThat(summary).isEqualTo(expectedSummary);
     }
 
     @Test
@@ -138,9 +142,10 @@ class ChildDateOfBirthCalculatorTest {
                 DOB_TURNS_FOUR_IN_NEXT_PAYMENT_CYCLE
         );
         //When
-        int numChildrenTurningFour = childDateOfBirthCalculator.getNumberOfChildrenTurningFourAffectingNextPayment(paymentCycle);
+        NextPaymentCycleSummary summary = childDateOfBirthCalculator.getChildrenDateOfBirthSummaryAffectingNextPayment(paymentCycle);
         //Then
-        assertThat(numChildrenTurningFour).isEqualTo(2);
+        NextPaymentCycleSummary expectedSummary = NextPaymentCycleSummary.builder().numberOfChildrenTurningFour(2).build();
+        assertThat(summary).isEqualTo(expectedSummary);
     }
 
     @Test
@@ -148,9 +153,9 @@ class ChildDateOfBirthCalculatorTest {
         //Given a PaymentCycle with no children dobs in it
         PaymentCycle paymentCycle = aPaymentCycleWithPregnancyVouchersOnly(LocalDate.now(), LocalDate.now().plusWeeks(4));
         //When
-        int numChildrenTurningFour = childDateOfBirthCalculator.getNumberOfChildrenTurningFourAffectingNextPayment(paymentCycle);
+        NextPaymentCycleSummary summary = childDateOfBirthCalculator.getChildrenDateOfBirthSummaryAffectingNextPayment(paymentCycle);
         //Then
-        assertThat(numChildrenTurningFour).isEqualTo(0);
+        assertThat(summary).isEqualTo(NO_CHILDREN);
     }
 
     @Test
@@ -161,9 +166,9 @@ class ChildDateOfBirthCalculatorTest {
                 ELDEST_CHILD_DOB
         );
         //When
-        int numChildrenTurningOne = childDateOfBirthCalculator.getNumberOfChildrenTurningOneAffectingNextPayment(paymentCycle);
+        NextPaymentCycleSummary summary = childDateOfBirthCalculator.getChildrenDateOfBirthSummaryAffectingNextPayment(paymentCycle);
         //Then
-        assertThat(numChildrenTurningOne).isEqualTo(0);
+        assertThat(summary).isEqualTo(NO_CHILDREN);
     }
 
     @Test
@@ -174,9 +179,10 @@ class ChildDateOfBirthCalculatorTest {
                 ELDEST_CHILD_DOB
         );
         //When
-        int numChildrenTurningOne = childDateOfBirthCalculator.getNumberOfChildrenTurningOneAffectingNextPayment(paymentCycle);
+        NextPaymentCycleSummary summary = childDateOfBirthCalculator.getChildrenDateOfBirthSummaryAffectingNextPayment(paymentCycle);
         //Then
-        assertThat(numChildrenTurningOne).isEqualTo(1);
+        NextPaymentCycleSummary expectedSummary = NextPaymentCycleSummary.builder().numberOfChildrenTurningOne(1).build();
+        assertThat(summary).isEqualTo(expectedSummary);
     }
 
     @Test
@@ -187,9 +193,10 @@ class ChildDateOfBirthCalculatorTest {
                 ELDEST_CHILD_DOB
         );
         //When
-        int numChildrenTurningOne = childDateOfBirthCalculator.getNumberOfChildrenTurningOneAffectingNextPayment(paymentCycle);
+        NextPaymentCycleSummary summary = childDateOfBirthCalculator.getChildrenDateOfBirthSummaryAffectingNextPayment(paymentCycle);
         //Then
-        assertThat(numChildrenTurningOne).isEqualTo(1);
+        NextPaymentCycleSummary expectedSummary = NextPaymentCycleSummary.builder().numberOfChildrenTurningOne(1).build();
+        assertThat(summary).isEqualTo(expectedSummary);
     }
 
     @Test
@@ -200,9 +207,9 @@ class ChildDateOfBirthCalculatorTest {
                 ELDEST_CHILD_DOB
         );
         //When
-        int numChildrenTurningOne = childDateOfBirthCalculator.getNumberOfChildrenTurningOneAffectingNextPayment(paymentCycle);
+        NextPaymentCycleSummary summary = childDateOfBirthCalculator.getChildrenDateOfBirthSummaryAffectingNextPayment(paymentCycle);
         //Then
-        assertThat(numChildrenTurningOne).isEqualTo(0);
+        assertThat(summary).isEqualTo(NO_CHILDREN);
     }
 
     @Test
@@ -213,9 +220,9 @@ class ChildDateOfBirthCalculatorTest {
                 ELDEST_CHILD_DOB
         );
         //When
-        int numChildrenTurningOne = childDateOfBirthCalculator.getNumberOfChildrenTurningOneAffectingNextPayment(paymentCycle);
+        NextPaymentCycleSummary summary = childDateOfBirthCalculator.getChildrenDateOfBirthSummaryAffectingNextPayment(paymentCycle);
         //Then
-        assertThat(numChildrenTurningOne).isEqualTo(0);
+        assertThat(summary).isEqualTo(NO_CHILDREN);
     }
 
     @Test
@@ -226,9 +233,10 @@ class ChildDateOfBirthCalculatorTest {
                 ELDEST_CHILD_DOB
         );
         //When
-        int numChildrenTurningOne = childDateOfBirthCalculator.getNumberOfChildrenTurningOneAffectingNextPayment(paymentCycle);
+        NextPaymentCycleSummary summary = childDateOfBirthCalculator.getChildrenDateOfBirthSummaryAffectingNextPayment(paymentCycle);
         //Then
-        assertThat(numChildrenTurningOne).isEqualTo(1);
+        NextPaymentCycleSummary expectedSummary = NextPaymentCycleSummary.builder().numberOfChildrenTurningOne(1).build();
+        assertThat(summary).isEqualTo(expectedSummary);
     }
 
     @Test
@@ -240,9 +248,10 @@ class ChildDateOfBirthCalculatorTest {
                 ELDEST_CHILD_DOB
         );
         //When
-        int numChildrenTurningOne = childDateOfBirthCalculator.getNumberOfChildrenTurningOneAffectingNextPayment(paymentCycle);
+        NextPaymentCycleSummary summary = childDateOfBirthCalculator.getChildrenDateOfBirthSummaryAffectingNextPayment(paymentCycle);
         //Then
-        assertThat(numChildrenTurningOne).isEqualTo(2);
+        NextPaymentCycleSummary expectedSummary = NextPaymentCycleSummary.builder().numberOfChildrenTurningOne(2).build();
+        assertThat(summary).isEqualTo(expectedSummary);
     }
 
     @Test
@@ -250,9 +259,23 @@ class ChildDateOfBirthCalculatorTest {
         //Given a PaymentCycle with no children dobs in it
         PaymentCycle paymentCycle = aPaymentCycleWithPregnancyVouchersOnly(LocalDate.now(), LocalDate.now().plusWeeks(4));
         //When
-        int numChildrenTurningOne = childDateOfBirthCalculator.getNumberOfChildrenTurningOneAffectingNextPayment(paymentCycle);
+        NextPaymentCycleSummary summary = childDateOfBirthCalculator.getChildrenDateOfBirthSummaryAffectingNextPayment(paymentCycle);
         //Then
-        assertThat(numChildrenTurningOne).isEqualTo(0);
+        assertThat(summary).isEqualTo(NO_CHILDREN);
+    }
+
+    @Test
+    void shouldReturnChildrenTurningOneAndChildTurningFourInPaymentCycle() {
+        //Given one child will turn 1 and another will turn 4 in the next PaymentCycle
+        PaymentCycle paymentCycle = buildPaymentCycleWithChildDobs(
+                DOB_TURNS_ONE_IN_NEXT_PAYMENT_CYCLE,
+                DOB_TURNS_FOUR_IN_NEXT_PAYMENT_CYCLE
+        );
+        //When
+        NextPaymentCycleSummary summary = childDateOfBirthCalculator.getChildrenDateOfBirthSummaryAffectingNextPayment(paymentCycle);
+        //Then
+        NextPaymentCycleSummary expectedSummary = NextPaymentCycleSummary.builder().numberOfChildrenTurningOne(1).numberOfChildrenTurningFour(1).build();
+        assertThat(summary).isEqualTo(expectedSummary);
     }
 
     private PaymentCycle buildPaymentCycleWithChildDobs(LocalDate... childDobs) {

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/processor/NextPaymentCycleSummaryTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/processor/NextPaymentCycleSummaryTest.java
@@ -1,0 +1,60 @@
+package uk.gov.dhsc.htbhf.claimant.message.processor;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.dhsc.htbhf.claimant.message.processor.NextPaymentCycleSummary.NO_CHILDREN;
+
+class NextPaymentCycleSummaryTest {
+
+    @ParameterizedTest
+    @CsvSource({"0, false",
+            "1, true",
+            "2, true",
+            "15, true"})
+    void testHasChildrenTurningFour(int childrenTurningFour, boolean expected) {
+        NextPaymentCycleSummary summary = NextPaymentCycleSummary.builder().numberOfChildrenTurningFour(childrenTurningFour).build();
+        assertThat(summary.hasChildrenTurningFour()).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"0, false",
+            "1, false",
+            "2, true",
+            "15, true"})
+    void testHasMultipleChildrenTurningFour(int childrenTurningFour, boolean expected) {
+        NextPaymentCycleSummary summary = NextPaymentCycleSummary.builder().numberOfChildrenTurningFour(childrenTurningFour).build();
+        assertThat(summary.hasMultipleChildrenTurningFour()).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"0, false",
+            "1, true",
+            "2, true",
+            "15, true"})
+    void testHasChildrenTurningOne(int childrenTurningOne, boolean expected) {
+        NextPaymentCycleSummary summary = NextPaymentCycleSummary.builder().numberOfChildrenTurningOne(childrenTurningOne).build();
+        assertThat(summary.hasChildrenTurningOne()).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"0, false",
+            "1, false",
+            "2, true",
+            "15, true"})
+    void testHasMultipleChildrenTurningOne(int childrenTurningOne, boolean expected) {
+        NextPaymentCycleSummary summary = NextPaymentCycleSummary.builder().numberOfChildrenTurningOne(childrenTurningOne).build();
+        assertThat(summary.hasMultipleChildrenTurningOne()).isEqualTo(expected);
+    }
+
+    @Test
+    void testCheckNoChildren() {
+        assertThat(NO_CHILDREN.getNumberOfChildrenTurningFour()).isZero();
+        assertThat(NO_CHILDREN.getNumberOfChildrenTurningOne()).isZero();
+        assertThat(NO_CHILDREN.hasMultipleChildrenTurningOne()).isFalse();
+        assertThat(NO_CHILDREN.hasMultipleChildrenTurningFour()).isFalse();
+    }
+
+}


### PR DESCRIPTION
…that would affect the next PaymentCycle.

No change to the processing in the MakePaymentMessageProcessor, have simply created a new class to store calculated summary information which can be used to determine if new emails can/should be sent out at a new PaymentCycle. Next PR will add implementation for Child Turns 1 email to the processor.