### PR TITLE
HTBHF-2326 Fix issue with total amount in emails being that of the …

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/MessagePayloadFactory.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/MessagePayloadFactory.java
@@ -118,7 +118,7 @@ public class MessagePayloadFactory {
         Map<String, Object> emailPersonalisation = new HashMap<>();
         emailPersonalisation.put(EmailTemplateKey.FIRST_NAME.getTemplateKeyName(), claimant.getFirstName());
         emailPersonalisation.put(EmailTemplateKey.LAST_NAME.getTemplateKeyName(), claimant.getLastName());
-        String paymentAmount = convertPenceToPounds(paymentCycle.getTotalEntitlementAmountInPence());
+        String paymentAmount = convertPenceToPounds(voucherEntitlement.getTotalVoucherValueInPence());
         emailPersonalisation.put(EmailTemplateKey.PAYMENT_AMOUNT.getTemplateKeyName(), paymentAmount);
         emailPersonalisation.put(EmailTemplateKey.PREGNANCY_PAYMENT.getTemplateKeyName(), buildPregnancyPaymentAmountSummary(voucherEntitlement));
         emailPersonalisation.put(EmailTemplateKey.CHILDREN_UNDER_1_PAYMENT.getTemplateKeyName(), buildUnder1PaymentSummary(voucherEntitlement));

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/EmailPayloadAssertions.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/EmailPayloadAssertions.java
@@ -35,21 +35,19 @@ public class EmailPayloadAssertions {
 
     /**
      * Asserts that the values are correct for an email where we notify the claimant that their entitlement will be changing
-     * because one or more of their children will be turning 4 in the next payment cycle. The method assumes that they will be receiving
-     * 4 vouchers for children under 1 and is specifically different to the standard number of vouchers in the PaymentCycles
-     * built by the test data factory.
+     * because one or more of their children will be turning 4 in the next payment cycle.
      *
      * @param emailPersonalisation The map of data to verify
      * @param nextPaymentDate      The payment date expected in the Map.
      */
-    public static void assertEmailPayloadCorrectForChildUnderFourNotificationWithNoPregnancyVouchers(Map<String, Object> emailPersonalisation,
-                                                                                                     LocalDate nextPaymentDate) {
+    public static void assertEmailPayloadCorrectForChildUnderFourNotificationWithPregnancyVouchers(Map<String, Object> emailPersonalisation,
+                                                                                                   LocalDate nextPaymentDate) {
         assertThat(emailPersonalisation).containsOnly(
                 entry("First_name", VALID_FIRST_NAME),
                 entry("Last_name", VALID_LAST_NAME),
-                entry("payment_amount", "£49.60"),
-                entry("pregnancy_payment", ""),
-                entry("children_under_1_payment", "\n* £49.60 for children under 1"),
+                entry("payment_amount", "£37.20"),
+                entry("pregnancy_payment", "\n* £12.40 for a pregnancy"),
+                entry("children_under_1_payment", "\n* £24.80 for children under 1"),
                 entry("children_under_4_payment", ""),
                 entry("multiple_children", false),
                 entry("next_payment_date", DATE_FORMATTER.format(nextPaymentDate))

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/MessagePayloadFactoryTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/MessagePayloadFactoryTest.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
-import static uk.gov.dhsc.htbhf.claimant.message.EmailPayloadAssertions.assertEmailPayloadCorrectForChildUnderFourNotificationWithNoPregnancyVouchers;
+import static uk.gov.dhsc.htbhf.claimant.message.EmailPayloadAssertions.assertEmailPayloadCorrectForChildUnderFourNotificationWithPregnancyVouchers;
 import static uk.gov.dhsc.htbhf.claimant.message.EmailPayloadAssertions.assertEmailPayloadCorrectForClaimantWithAllVouchers;
 import static uk.gov.dhsc.htbhf.claimant.message.EmailPayloadAssertions.assertEmailPayloadCorrectForClaimantWithPregnancyVouchersOnly;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimTestDataFactory.aValidClaim;
@@ -22,7 +22,7 @@ import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aPaymentCycleWithStartAndEndDate;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aValidPaymentCycle;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementWithVouchers;
-import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementWithVouchersForUnderOneOnly;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementWithVouchersForUnderOne;
 
 class MessagePayloadFactoryTest {
 
@@ -109,7 +109,7 @@ class MessagePayloadFactoryTest {
         LocalDate endDate = startDate.plusDays(28);
         PaymentCycle paymentCycle = aPaymentCycleWithStartAndEndDate(startDate, endDate);
         //This is specifically built so that it is different to the voucher entitlement on the PaymentCycle - it has no vouchers for under 4
-        PaymentCycleVoucherEntitlement paymentCycleVoucherEntitlement = aPaymentCycleVoucherEntitlementWithVouchersForUnderOneOnly(startDate);
+        PaymentCycleVoucherEntitlement paymentCycleVoucherEntitlement = aPaymentCycleVoucherEntitlementWithVouchersForUnderOne(startDate);
         boolean multipleChildrenTurningFourInMonth = false;
 
         EmailMessagePayload payload = MessagePayloadFactory.buildChildTurnsFourNotificationEmailPayload(paymentCycle,
@@ -117,7 +117,7 @@ class MessagePayloadFactoryTest {
 
         assertThat(payload.getClaimId()).isEqualTo(paymentCycle.getClaim().getId());
         assertThat(payload.getEmailType()).isEqualTo(EmailType.CHILD_TURNS_FOUR);
-        assertEmailPayloadCorrectForChildUnderFourNotificationWithNoPregnancyVouchers(payload.getEmailPersonalisation(), endDate.plusDays(1));
+        assertEmailPayloadCorrectForChildUnderFourNotificationWithPregnancyVouchers(payload.getEmailPersonalisation(), endDate.plusDays(1));
     }
 
     @Test

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/processor/PaymentCycleEmailHandlerTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/processor/PaymentCycleEmailHandlerTest.java
@@ -25,9 +25,9 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
-import static uk.gov.dhsc.htbhf.claimant.message.EmailPayloadAssertions.assertEmailPayloadCorrectForChildUnderFourNotificationWithNoPregnancyVouchers;
+import static uk.gov.dhsc.htbhf.claimant.message.EmailPayloadAssertions.assertEmailPayloadCorrectForChildUnderFourNotificationWithPregnancyVouchers;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aValidPaymentCycle;
-import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementWithVouchersForUnderOneOnly;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementWithVouchersForUnderOne;
 
 @ExtendWith(MockitoExtension.class)
 class PaymentCycleEmailHandlerTest {
@@ -53,7 +53,7 @@ class PaymentCycleEmailHandlerTest {
         NextPaymentCycleSummary nextPaymentCycleSummary = NextPaymentCycleSummary.builder().numberOfChildrenTurningFour(1).build();
         given(childDateOfBirthCalculator.getNextPaymentCycleSummary(any())).willReturn(nextPaymentCycleSummary);
         //This entitlement specifically has no vouchers for 1-4 year olds.
-        PaymentCycleVoucherEntitlement nextEntitlement = aPaymentCycleVoucherEntitlementWithVouchersForUnderOneOnly(START_OF_NEXT_CYCLE);
+        PaymentCycleVoucherEntitlement nextEntitlement = aPaymentCycleVoucherEntitlementWithVouchersForUnderOne(START_OF_NEXT_CYCLE);
         given(paymentCycleEntitlementCalculator.calculateEntitlement(any(), any(), any(), any())).willReturn(nextEntitlement);
 
         paymentCycleEmailHandler.handleAdditionalEmails(paymentCycle);
@@ -85,7 +85,7 @@ class PaymentCycleEmailHandlerTest {
         EmailMessagePayload payload = (EmailMessagePayload) messagePayload;
         assertThat(payload.getEmailType()).isEqualTo(EmailType.CHILD_TURNS_FOUR);
         assertThat(payload.getClaimId()).isEqualTo(paymentCycle.getClaim().getId());
-        assertEmailPayloadCorrectForChildUnderFourNotificationWithNoPregnancyVouchers(payload.getEmailPersonalisation(),
+        assertEmailPayloadCorrectForChildUnderFourNotificationWithPregnancyVouchers(payload.getEmailPersonalisation(),
                 paymentCycle.getCycleEndDate().plusDays(1));
     }
 

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/PaymentCycleVoucherEntitlementTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/PaymentCycleVoucherEntitlementTestDataFactory.java
@@ -28,12 +28,12 @@ public class PaymentCycleVoucherEntitlementTestDataFactory {
         );
     }
 
-    public static PaymentCycleVoucherEntitlement aPaymentCycleVoucherEntitlementWithVouchersForUnderOneOnly(LocalDate startDate) {
+    public static PaymentCycleVoucherEntitlement aPaymentCycleVoucherEntitlementWithVouchersForUnderOne(LocalDate startDate) {
         return buildPaymentCycleVoucherEntitlement(
-                aVoucherEntitlementWithVouchersForUnderOneOnly(startDate),
-                aVoucherEntitlementWithVouchersForUnderOneOnly(startDate.plusWeeks(1)),
-                aVoucherEntitlementWithVouchersForUnderOneOnly(startDate.plusWeeks(2)),
-                aVoucherEntitlementWithVouchersForUnderOneOnly(startDate.plusWeeks(3))
+                aVoucherEntitlementWithVouchersForUnderOne(startDate),
+                aVoucherEntitlementWithVouchersForUnderOne(startDate.plusWeeks(1)),
+                aVoucherEntitlementWithVouchersForUnderOne(startDate.plusWeeks(2)),
+                aVoucherEntitlementWithVouchersForUnderOne(startDate.plusWeeks(3))
         );
     }
 

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/VoucherEntitlementTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/VoucherEntitlementTestDataFactory.java
@@ -26,12 +26,12 @@ public class VoucherEntitlementTestDataFactory {
                 .build();
     }
 
-    public static VoucherEntitlement aVoucherEntitlementWithVouchersForUnderOneOnly(LocalDate entitlementDate) {
+    public static VoucherEntitlement aVoucherEntitlementWithVouchersForUnderOne(LocalDate entitlementDate) {
         return VoucherEntitlement.builder()
                 .singleVoucherValueInPence(VOUCHER_VALUE_IN_PENCE)
-                .vouchersForChildrenUnderOne(4)
+                .vouchersForChildrenUnderOne(2)
                 .vouchersForChildrenBetweenOneAndFour(0)
-                .vouchersForPregnancy(0)
+                .vouchersForPregnancy(1)
                 .entitlementDate(entitlementDate)
                 .build();
     }


### PR DESCRIPTION
…current payment cycle, not the new entitlement.

The problem was hidden by the fact that even though the breakdown of the vouchers was different in the unit tests between the original PaymentCycle and the new entitlement, the total amount was actually the same. Test has been corrected and bug now rectified.