### PR TITLE
HTBHF-2008 Moved buildChildTurnsFourNotificationEmailPayload() out of…

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/MessagePayloadFactory.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/MessagePayloadFactory.java
@@ -71,27 +71,6 @@ public class MessagePayloadFactory {
     }
 
     /**
-     * Builds the message payload for the email that gets sent should one of the claimants children be turning
-     * 4 during the next payment cycle.
-     *
-     * @param paymentCycle                       The current payment cycle
-     * @param entitlementNextMonth               The entitlement that the claimant will be receiving next month
-     * @param multipleChildrenTurningFourInMonth Whether or not there are multiple children turning 4 next month
-     * @return The build email payload.
-     */
-    public static EmailMessagePayload buildChildTurnsFourNotificationEmailPayload(PaymentCycle paymentCycle,
-                                                                                  PaymentCycleVoucherEntitlement entitlementNextMonth,
-                                                                                  boolean multipleChildrenTurningFourInMonth) {
-        Map<String, Object> emailPersonalisation = createPaymentEmailPersonalisationMap(paymentCycle, entitlementNextMonth);
-        emailPersonalisation.put(EmailTemplateKey.MULTIPLE_CHILDREN.getTemplateKeyName(), multipleChildrenTurningFourInMonth);
-        return EmailMessagePayload.builder()
-                .claimId(paymentCycle.getClaim().getId())
-                .emailType(EmailType.CHILD_TURNS_FOUR)
-                .emailPersonalisation(emailPersonalisation)
-                .build();
-    }
-
-    /**
      * Builds the message payload for the email that gets sent when a claim is no longer Eligible.
      *
      * @param claim The claim that is no longer eligible.
@@ -106,14 +85,7 @@ public class MessagePayloadFactory {
                 .build();
     }
 
-    private static Map<String, Object> createClaimNoLongerEligibleEmailPersonalisationMap(Claimant claimant) {
-        return Map.of(
-                EmailTemplateKey.FIRST_NAME.getTemplateKeyName(), claimant.getFirstName(),
-                EmailTemplateKey.LAST_NAME.getTemplateKeyName(), claimant.getLastName()
-        );
-    }
-
-    private static Map<String, Object> createPaymentEmailPersonalisationMap(PaymentCycle paymentCycle, PaymentCycleVoucherEntitlement voucherEntitlement) {
+    public static Map<String, Object> createPaymentEmailPersonalisationMap(PaymentCycle paymentCycle, PaymentCycleVoucherEntitlement voucherEntitlement) {
         Claimant claimant = paymentCycle.getClaim().getClaimant();
         Map<String, Object> emailPersonalisation = new HashMap<>();
         emailPersonalisation.put(EmailTemplateKey.FIRST_NAME.getTemplateKeyName(), claimant.getFirstName());
@@ -126,6 +98,13 @@ public class MessagePayloadFactory {
         String formattedCycleEndDate = paymentCycle.getCycleEndDate().plusDays(1).format(DATE_FORMATTER);
         emailPersonalisation.put(EmailTemplateKey.NEXT_PAYMENT_DATE.getTemplateKeyName(), formattedCycleEndDate);
         return emailPersonalisation;
+    }
+
+    private static Map<String, Object> createClaimNoLongerEligibleEmailPersonalisationMap(Claimant claimant) {
+        return Map.of(
+                EmailTemplateKey.FIRST_NAME.getTemplateKeyName(), claimant.getFirstName(),
+                EmailTemplateKey.LAST_NAME.getTemplateKeyName(), claimant.getLastName()
+        );
     }
 
     private static String buildPregnancyPaymentAmountSummary(PaymentCycleVoucherEntitlement voucherEntitlement) {

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/processor/PaymentCycleEmailHandler.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/processor/PaymentCycleEmailHandler.java
@@ -6,14 +6,17 @@ import org.springframework.stereotype.Component;
 import uk.gov.dhsc.htbhf.claimant.entitlement.PaymentCycleEntitlementCalculator;
 import uk.gov.dhsc.htbhf.claimant.entitlement.PaymentCycleVoucherEntitlement;
 import uk.gov.dhsc.htbhf.claimant.entity.PaymentCycle;
+import uk.gov.dhsc.htbhf.claimant.message.EmailTemplateKey;
 import uk.gov.dhsc.htbhf.claimant.message.MessageQueueClient;
 import uk.gov.dhsc.htbhf.claimant.message.MessageType;
 import uk.gov.dhsc.htbhf.claimant.message.payload.EmailMessagePayload;
+import uk.gov.dhsc.htbhf.claimant.message.payload.EmailType;
 
 import java.time.LocalDate;
+import java.util.Map;
 import java.util.Optional;
 
-import static uk.gov.dhsc.htbhf.claimant.message.MessagePayloadFactory.buildChildTurnsFourNotificationEmailPayload;
+import static uk.gov.dhsc.htbhf.claimant.message.MessagePayloadFactory.createPaymentEmailPersonalisationMap;
 
 /**
  * Component responsible for determining if any additional emails need to be sent out in addition to
@@ -53,6 +56,18 @@ public class PaymentCycleEmailHandler {
                 currentPaymentCycle.getChildrenDob(),
                 nextCycleStartDate,
                 currentPaymentCycle.getVoucherEntitlement());
+    }
+
+    private EmailMessagePayload buildChildTurnsFourNotificationEmailPayload(PaymentCycle paymentCycle,
+                                                                            PaymentCycleVoucherEntitlement entitlementNextMonth,
+                                                                            boolean multipleChildrenTurningFourInMonth) {
+        Map<String, Object> emailPersonalisation = createPaymentEmailPersonalisationMap(paymentCycle, entitlementNextMonth);
+        emailPersonalisation.put(EmailTemplateKey.MULTIPLE_CHILDREN.getTemplateKeyName(), multipleChildrenTurningFourInMonth);
+        return EmailMessagePayload.builder()
+                .claimId(paymentCycle.getClaim().getId())
+                .emailType(EmailType.CHILD_TURNS_FOUR)
+                .emailPersonalisation(emailPersonalisation)
+                .build();
     }
 
 }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/MessagePayloadFactoryTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/MessagePayloadFactoryTest.java
@@ -14,7 +14,6 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
-import static uk.gov.dhsc.htbhf.claimant.message.EmailPayloadAssertions.assertEmailPayloadCorrectForChildUnderFourNotificationWithPregnancyVouchers;
 import static uk.gov.dhsc.htbhf.claimant.message.EmailPayloadAssertions.assertEmailPayloadCorrectForClaimantWithAllVouchers;
 import static uk.gov.dhsc.htbhf.claimant.message.EmailPayloadAssertions.assertEmailPayloadCorrectForClaimantWithPregnancyVouchersOnly;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimTestDataFactory.aValidClaim;
@@ -22,7 +21,6 @@ import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aPaymentCycleWithStartAndEndDate;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aValidPaymentCycle;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementWithVouchers;
-import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementWithVouchersForUnderOne;
 
 class MessagePayloadFactoryTest {
 
@@ -51,7 +49,6 @@ class MessagePayloadFactoryTest {
 
     @Test
     void shouldBuildSendNewCardSuccessEmailPayloadWithAllPaymentTypes() {
-
         LocalDate startDate = LocalDate.now();
         LocalDate endDate = startDate.plusDays(28);
         PaymentCycle paymentCycle = aPaymentCycleWithStartAndEndDate(startDate, endDate);
@@ -101,23 +98,6 @@ class MessagePayloadFactoryTest {
         assertThat(payload.getClaimId()).isEqualTo(paymentCycle.getClaim().getId());
         assertThat(payload.getEmailType()).isEqualTo(EmailType.PAYMENT);
         assertEmailPayloadCorrectForClaimantWithPregnancyVouchersOnly(payload.getEmailPersonalisation(), endDate.plusDays(1));
-    }
-
-    @Test
-    void shouldBuildChildTurnsFourNotificationEmailPayload() {
-        LocalDate startDate = LocalDate.now();
-        LocalDate endDate = startDate.plusDays(28);
-        PaymentCycle paymentCycle = aPaymentCycleWithStartAndEndDate(startDate, endDate);
-        //This is specifically built so that it is different to the voucher entitlement on the PaymentCycle - it has no vouchers for under 4
-        PaymentCycleVoucherEntitlement paymentCycleVoucherEntitlement = aPaymentCycleVoucherEntitlementWithVouchersForUnderOne(startDate);
-        boolean multipleChildrenTurningFourInMonth = false;
-
-        EmailMessagePayload payload = MessagePayloadFactory.buildChildTurnsFourNotificationEmailPayload(paymentCycle,
-                paymentCycleVoucherEntitlement, multipleChildrenTurningFourInMonth);
-
-        assertThat(payload.getClaimId()).isEqualTo(paymentCycle.getClaim().getId());
-        assertThat(payload.getEmailType()).isEqualTo(EmailType.CHILD_TURNS_FOUR);
-        assertEmailPayloadCorrectForChildUnderFourNotificationWithPregnancyVouchers(payload.getEmailPersonalisation(), endDate.plusDays(1));
     }
 
     @Test


### PR DESCRIPTION
- Moved buildChildTurnsFourNotificationEmailPayload() out of payload test factory and into PaymentCycleEmailHandler.
- Future PRs will move further methods out of the MessagePayloadFactory.