### PR TITLE
HTBHF-2182 Setting a claim to expired when they have no vouchers.

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/audit/ClaimEventType.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/audit/ClaimEventType.java
@@ -11,5 +11,6 @@ public enum ClaimEventType implements EventType {
     NEW_CARD,
     MAKE_PAYMENT,
     BALANCE_TOO_HIGH_FOR_PAYMENT,
-    FAILED_EMAIL
+    FAILED_EMAIL,
+    CLAIM_EXPIRED
 }

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/audit/ClaimExpiredEvent.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/audit/ClaimExpiredEvent.java
@@ -1,0 +1,16 @@
+package uk.gov.dhsc.htbhf.claimant.service.audit;
+
+import uk.gov.dhsc.htbhf.logging.event.Event;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+import static uk.gov.dhsc.htbhf.claimant.service.audit.ClaimEventMetadataKey.*;
+
+public class ClaimExpiredEvent extends Event {
+
+    public ClaimExpiredEvent(UUID claimId) {
+        super(ClaimEventType.CLAIM_EXPIRED, LocalDateTime.now(), Map.of(CLAIM_ID.getKey(), claimId));
+    }
+}

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/audit/EventAuditor.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/audit/EventAuditor.java
@@ -97,4 +97,9 @@ public class EventAuditor {
     public void auditFailedEvent(FailureEvent failureEvent) {
         eventLogger.logEvent(failureEvent);
     }
+
+    public void auditClaimExpired(Claim claim) {
+        ClaimExpiredEvent event = new ClaimExpiredEvent(claim.getId());
+        eventLogger.logEvent(event);
+    }
 }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/processor/DetermineEntitlementMessageProcessorTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/processor/DetermineEntitlementMessageProcessorTest.java
@@ -9,7 +9,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.dhsc.htbhf.claimant.communications.ClaimEmailHandler;
+import uk.gov.dhsc.htbhf.claimant.entitlement.PaymentCycleVoucherEntitlement;
 import uk.gov.dhsc.htbhf.claimant.entity.Claim;
+import uk.gov.dhsc.htbhf.claimant.entity.Claimant;
 import uk.gov.dhsc.htbhf.claimant.entity.Message;
 import uk.gov.dhsc.htbhf.claimant.entity.PaymentCycle;
 import uk.gov.dhsc.htbhf.claimant.message.MessagePayloadFactory;
@@ -23,11 +25,13 @@ import uk.gov.dhsc.htbhf.claimant.model.ClaimStatus;
 import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityAndEntitlementDecision;
 import uk.gov.dhsc.htbhf.claimant.repository.ClaimRepository;
 import uk.gov.dhsc.htbhf.claimant.service.EligibilityAndEntitlementService;
+import uk.gov.dhsc.htbhf.claimant.service.audit.EventAuditor;
 import uk.gov.dhsc.htbhf.claimant.service.payments.PaymentCycleService;
 import uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus;
 
 import java.time.LocalDate;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -35,12 +39,18 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static uk.gov.dhsc.htbhf.claimant.message.MessageStatus.COMPLETED;
 import static uk.gov.dhsc.htbhf.claimant.message.MessageType.DETERMINE_ENTITLEMENT;
+import static uk.gov.dhsc.htbhf.claimant.model.ClaimStatus.EXPIRED;
+import static uk.gov.dhsc.htbhf.claimant.model.ClaimStatus.PENDING_EXPIRY;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimTestDataFactory.aClaimWithExpectedDeliveryDate;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimTestDataFactory.aValidClaimBuilder;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimantTestDataFactory.aClaimantWithNoChildrenAndNotPregnant;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.EligibilityAndEntitlementTestDataFactory.aDecisionWithEntitlement;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.EligibilityAndEntitlementTestDataFactory.aDecisionWithStatus;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.MessageContextTestDataFactory.aDetermineEntitlementMessageContext;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.MessageTestDataFactory.aValidMessageWithType;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aPaymentCycleWithClaim;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aPaymentCycleWithStartDateAndClaim;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementMatchingChildren;
 import static uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus.ELIGIBLE;
 
 @ExtendWith(MockitoExtension.class)
@@ -60,6 +70,8 @@ class DetermineEntitlementMessageProcessorTest {
     private MessageQueueClient messageQueueClient;
     @Mock
     private ClaimEmailHandler claimEmailHandler;
+    @Mock
+    private EventAuditor eventAuditor;
 
     @InjectMocks
     private DetermineEntitlementMessageProcessor processor;
@@ -118,25 +130,64 @@ class DetermineEntitlementMessageProcessorTest {
                 context.getPreviousPaymentCycle());
 
         verify(paymentCycleService).updatePaymentCycle(context.getCurrentPaymentCycle(), decision);
-        verifyClaimSavedAsPendingExpiry();
+        verifyClaimSavedWithStatus(PENDING_EXPIRY);
         verify(claimEmailHandler).sendClaimNoLongerEligibleEmail(context.getClaim());
     }
 
-    private void verifyClaimSavedAsPendingExpiry() {
+    @ParameterizedTest
+    @CsvSource({"ACTIVE", "PENDING_EXPIRY"})
+    void shouldSetClaimToExpiredWhenClaimantIsNotPregnantAndHasNoChildrenUnderFour(ClaimStatus claimStatus) {
+        //Given
+        DetermineEntitlementMessageContext context = buildMessageContextWithNoChildrenAndNotPregnant(claimStatus);
+        given(messageContextLoader.loadDetermineEntitlementContext(any())).willReturn(context);
+
+        //Eligibility
+        PaymentCycleVoucherEntitlement voucherEntitlement
+                = aPaymentCycleVoucherEntitlementMatchingChildren(context.getCurrentPaymentCycle().getCycleStartDate(), emptyList());
+        EligibilityAndEntitlementDecision decision = aDecisionWithEntitlement(voucherEntitlement);
+        given(eligibilityAndEntitlementService.evaluateExistingClaimant(any(), any(), any())).willReturn(decision);
+
+        Message message = aValidMessageWithType(DETERMINE_ENTITLEMENT);
+
+        //When
+        MessageStatus messageStatus = processor.processMessage(message);
+
+        //Then
+        assertThat(messageStatus).isEqualTo(COMPLETED);
+        verify(messageContextLoader).loadDetermineEntitlementContext(message);
+        verify(eligibilityAndEntitlementService).evaluateExistingClaimant(context.getClaim().getClaimant(),
+                context.getCurrentPaymentCycle().getCycleStartDate(),
+                context.getPreviousPaymentCycle());
+        verify(paymentCycleService).updatePaymentCycle(context.getCurrentPaymentCycle(), decision);
+        verifyClaimSavedWithStatus(EXPIRED);
+        verify(eventAuditor).auditClaimExpired(context.getClaim());
+    }
+
+    private void verifyClaimSavedWithStatus(ClaimStatus claimStatus) {
         ArgumentCaptor<Claim> argumentCaptor = ArgumentCaptor.forClass(Claim.class);
         verify(claimRepository).save(argumentCaptor.capture());
         Claim claim = argumentCaptor.getValue();
-        assertThat(claim.getClaimStatus()).isEqualTo(ClaimStatus.PENDING_EXPIRY);
+        assertThat(claim.getClaimStatus()).isEqualTo(claimStatus);
+    }
+
+    private DetermineEntitlementMessageContext buildMessageContextWithNoChildrenAndNotPregnant(ClaimStatus claimStatus) {
+        Claimant claimant = aClaimantWithNoChildrenAndNotPregnant();
+        Claim claim = aValidClaimBuilder()
+                .claimant(claimant)
+                .claimStatus(claimStatus)
+                .build();
+
+        return buildMessageContext(claim);
     }
 
     private DetermineEntitlementMessageContext buildMessageContext() {
-        //Claim
         Claim claim = aClaimWithExpectedDeliveryDate(EXPECTED_DELIVERY_DATE);
+        return buildMessageContext(claim);
+    }
 
-        //Current payment cycle
+    private DetermineEntitlementMessageContext buildMessageContext(Claim claim) {
         PaymentCycle currentPaymentCycle = aPaymentCycleWithClaim(claim);
 
-        //Previous payment cycle
         LocalDate previousCycleStartDate = LocalDate.now().minusWeeks(4);
         PaymentCycle previousPaymentCycle = aPaymentCycleWithStartDateAndClaim(previousCycleStartDate, claim);
 

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/ClaimantTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/ClaimantTestDataFactory.java
@@ -7,6 +7,7 @@ import java.nio.CharBuffer;
 import java.time.LocalDate;
 import java.util.Arrays;
 
+import static java.util.Collections.emptyList;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.AddressTestDataFactory.aValidAddress;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.*;
 
@@ -62,6 +63,13 @@ public final class ClaimantTestDataFactory {
     public static Claimant aClaimantWithPhoneNumber(String phoneNumber) {
         return aValidClaimantBuilder()
                 .phoneNumber(phoneNumber)
+                .build();
+    }
+
+    public static Claimant aClaimantWithNoChildrenAndNotPregnant() {
+        return aValidClaimantBuilder()
+                .childrenDob(emptyList())
+                .expectedDeliveryDate(null)
                 .build();
     }
 

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/EligibilityAndEntitlementTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/EligibilityAndEntitlementTestDataFactory.java
@@ -20,6 +20,10 @@ public class EligibilityAndEntitlementTestDataFactory {
         return aValidDecisionBuilder().eligibilityStatus(eligibilityStatus).build();
     }
 
+    public static EligibilityAndEntitlementDecision aDecisionWithEntitlement(PaymentCycleVoucherEntitlement entitlement) {
+        return aValidDecisionBuilder().voucherEntitlement(entitlement).build();
+    }
+
     public static EligibilityAndEntitlementDecision aDecisionWithStatusAndEntitlement(EligibilityStatus eligibilityStatus,
                                                                                       PaymentCycleVoucherEntitlement entitlement) {
         return aValidDecisionBuilder()


### PR DESCRIPTION
- Setting a claim to expired when they have no children under for an aren't pregnant (entitlement decision contains no vouchers).