### PR TITLE
HTBHF-2010 Added dates of birth of children and claim action to repor…

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/MessagePayloadFactory.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/MessagePayloadFactory.java
@@ -6,8 +6,10 @@ import uk.gov.dhsc.htbhf.claimant.entity.PaymentCycle;
 import uk.gov.dhsc.htbhf.claimant.message.payload.MakePaymentMessagePayload;
 import uk.gov.dhsc.htbhf.claimant.message.payload.NewCardRequestMessagePayload;
 import uk.gov.dhsc.htbhf.claimant.message.payload.ReportClaimMessagePayload;
+import uk.gov.dhsc.htbhf.claimant.reporting.ClaimAction;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -33,9 +35,12 @@ public class MessagePayloadFactory {
                 .build();
     }
 
-    public static ReportClaimMessagePayload buildReportClaimMessagePayload(Claim claim) {
+    public static ReportClaimMessagePayload buildReportClaimMessagePayload(Claim claim, List<LocalDate> dateOfBirthOfChildren, ClaimAction claimAction) {
         return ReportClaimMessagePayload.builder()
                 .claimId(claim.getId())
+                .datesOfBirthOfChildren(dateOfBirthOfChildren)
+                .claimAction(claimAction)
+                .timestamp(LocalDateTime.now())
                 .build();
     }
 }

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/payload/ReportClaimMessagePayload.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/payload/ReportClaimMessagePayload.java
@@ -2,11 +2,18 @@ package uk.gov.dhsc.htbhf.claimant.message.payload;
 
 import lombok.Builder;
 import lombok.Data;
+import uk.gov.dhsc.htbhf.claimant.reporting.ClaimAction;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @Data
 @Builder
 public class ReportClaimMessagePayload implements MessagePayload {
     private UUID claimId;
+    private List<LocalDate> datesOfBirthOfChildren;
+    private ClaimAction claimAction;
+    private LocalDateTime timestamp;
 }

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/reporting/ClaimAction.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/reporting/ClaimAction.java
@@ -1,0 +1,8 @@
+package uk.gov.dhsc.htbhf.claimant.reporting;
+
+/**
+ * Action that triggered a claim event.
+ */
+public enum ClaimAction {
+    NEW
+}

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/reporting/MIReporter.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/reporting/MIReporter.java
@@ -41,6 +41,8 @@ public class MIReporter {
             claim.setPostcodeData(postcodeData);
             claimRepository.save(claim);
         }
+
+
     }
 
     private PostcodeData getPostcodeData(Claim claim) {

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/ClaimMessageSender.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/ClaimMessageSender.java
@@ -8,6 +8,10 @@ import uk.gov.dhsc.htbhf.claimant.message.payload.AdditionalPregnancyPaymentMess
 import uk.gov.dhsc.htbhf.claimant.message.payload.NewCardRequestMessagePayload;
 import uk.gov.dhsc.htbhf.claimant.message.payload.ReportClaimMessagePayload;
 import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityAndEntitlementDecision;
+import uk.gov.dhsc.htbhf.claimant.reporting.ClaimAction;
+
+import java.time.LocalDate;
+import java.util.List;
 
 import static uk.gov.dhsc.htbhf.claimant.message.MessagePayloadFactory.buildNewCardMessagePayload;
 import static uk.gov.dhsc.htbhf.claimant.message.MessagePayloadFactory.buildReportClaimMessagePayload;
@@ -24,8 +28,8 @@ public class ClaimMessageSender {
 
     private final MessageQueueClient messageQueueClient;
 
-    public void sendReportClaimMessage(Claim claim) {
-        ReportClaimMessagePayload payload = buildReportClaimMessagePayload(claim);
+    public void sendReportClaimMessage(Claim claim, List<LocalDate> datesOfBirthOfChildren, ClaimAction claimAction) {
+        ReportClaimMessagePayload payload = buildReportClaimMessagePayload(claim, datesOfBirthOfChildren, claimAction);
         messageQueueClient.sendMessage(payload, REPORT_CLAIM);
     }
 

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/MessagePayloadFactoryTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/MessagePayloadFactoryTest.java
@@ -4,11 +4,16 @@ import org.junit.jupiter.api.Test;
 import uk.gov.dhsc.htbhf.claimant.entitlement.PaymentCycleVoucherEntitlement;
 import uk.gov.dhsc.htbhf.claimant.entity.Claim;
 import uk.gov.dhsc.htbhf.claimant.entity.PaymentCycle;
-import uk.gov.dhsc.htbhf.claimant.message.payload.*;
+import uk.gov.dhsc.htbhf.claimant.message.payload.MakePaymentMessagePayload;
+import uk.gov.dhsc.htbhf.claimant.message.payload.NewCardRequestMessagePayload;
+import uk.gov.dhsc.htbhf.claimant.message.payload.ReportClaimMessagePayload;
+import uk.gov.dhsc.htbhf.claimant.reporting.ClaimAction;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.dhsc.htbhf.claimant.message.MessagePayloadFactory.buildReportClaimMessagePayload;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimTestDataFactory.aValidClaim;
@@ -43,9 +48,15 @@ class MessagePayloadFactoryTest {
     @Test
     void shouldBuildReportClaimMessagePayload() {
         Claim claim = aValidClaim();
+        List<LocalDate> datesOfBirthOfChildren = asList(LocalDate.now().minusYears(1), LocalDate.now().minusYears(2));
+        ClaimAction claimAction = ClaimAction.NEW;
+        LocalDateTime now = LocalDateTime.now();
 
-        ReportClaimMessagePayload payload = buildReportClaimMessagePayload(claim);
+        ReportClaimMessagePayload payload = buildReportClaimMessagePayload(claim, datesOfBirthOfChildren, claimAction);
 
         assertThat(payload.getClaimId()).isEqualTo(claim.getId());
+        assertThat(payload.getDatesOfBirthOfChildren()).isEqualTo(datesOfBirthOfChildren);
+        assertThat(payload.getClaimAction()).isEqualTo(claimAction);
+        assertThat(payload.getTimestamp()).isAfterOrEqualTo(now);
     }
 }


### PR DESCRIPTION
- Added dates of birth of children and claim action to report claim message
- Now only creating report claim message for a new claim (other cases are handled in other stories)
- Added ClaimAction enum that states what happened to trigger a report claim message, e.g. new, updated, pending_expiry-> active, pending_expiry->expired, etc.