### PR TITLE
HTBHF-2182 Added missing ITs for where the claimant was pregnant but …

### DIFF
--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/RepositoryMediator.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/RepositoryMediator.java
@@ -109,4 +109,12 @@ public class RepositoryMediator {
         return claimRepository.findClaim(claimId);
     }
 
+    /**
+     * Saves the given claim.
+     *
+     * @param claim The claim to be saved
+     */
+    public void saveClaim(Claim claim) {
+        claimRepository.save(claim);
+    }
 }


### PR DESCRIPTION
…is no longer pregnant, plus split out the two original ITs for this story as can currently only implement one of them.

All these tests apart from the one where DWP returns INELIGIBLE where they had children who were over 4 in previous cycle will be enabled by the end of this story (hence why we needed to split the test into two separate tests for INELIGIBLE and ELIGIBLE cases)