### PR TITLE
HTBHF-2182 Add method to determine if there are any children under 4 in the given PaymentCycle.

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/processor/ChildDateOfBirthCalculator.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/processor/ChildDateOfBirthCalculator.java
@@ -6,6 +6,7 @@ import uk.gov.dhsc.htbhf.claimant.entitlement.PaymentCycleEntitlementCalculator;
 import uk.gov.dhsc.htbhf.claimant.entity.PaymentCycle;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import static uk.gov.dhsc.htbhf.claimant.message.processor.NextPaymentCycleSummary.NO_CHILDREN;
 
@@ -47,6 +48,21 @@ public class ChildDateOfBirthCalculator {
                 .numberOfChildrenTurningOne(childrenAgedOneAffectingNextPayment)
                 .numberOfChildrenTurningFour(childrenAgedFourAffectingNextPayment)
                 .build();
+    }
+
+    /**
+     * Calculates whether there were any children under 4 at all at the start of the given PaymentCycle.
+     *
+     * @param paymentCycle The payment cycle to check
+     * @return true if any children were under 4 at the start of the given PaymentCycle.
+     */
+    public boolean hadChildrenUnder4AtStartOfPaymentCycle(PaymentCycle paymentCycle) {
+        List<LocalDate> childrenDob = paymentCycle.getChildrenDob();
+        if (CollectionUtils.isEmpty(childrenDob)) {
+            return false;
+        }
+        return paymentCycle.getChildrenDob().stream()
+                .anyMatch(childDob -> childDob.isAfter(paymentCycle.getCycleStartDate().minusYears(4)));
     }
 
     private int countChildrenOfAge(PaymentCycle paymentCycle, LocalDate lastEntitlementDateInCurrentCycle,

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/processor/ChildDateOfBirthCalculatorTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/processor/ChildDateOfBirthCalculatorTest.java
@@ -3,6 +3,9 @@ package uk.gov.dhsc.htbhf.claimant.message.processor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -11,12 +14,14 @@ import uk.gov.dhsc.htbhf.claimant.entity.PaymentCycle;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Stream;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.lenient;
 import static uk.gov.dhsc.htbhf.claimant.message.processor.NextPaymentCycleSummary.NO_CHILDREN;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aPaymentCycleWithChildrenDobs;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aPaymentCycleWithPregnancyVouchersOnly;
-import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aValidPaymentCycleBuilder;
 
 @ExtendWith(MockitoExtension.class)
 class ChildDateOfBirthCalculatorTest {
@@ -278,10 +283,49 @@ class ChildDateOfBirthCalculatorTest {
         assertThat(summary).isEqualTo(expectedSummary);
     }
 
+    @ParameterizedTest(name = "Children dobs={0}")
+    @MethodSource("provideArgumentsForChildrenUnderFour")
+    void shouldReturnChildrenAtStartOrPaymentCycle(List<LocalDate> childrenDobs) {
+        //Given a children under 4 in the PaymentCycle
+        PaymentCycle paymentCycle = aPaymentCycleWithChildrenDobs(childrenDobs);
+        //When
+        boolean hasChildren = childDateOfBirthCalculator.hadChildrenUnder4AtStartOfPaymentCycle(paymentCycle);
+        //Then
+        assertThat(hasChildren).isTrue();
+    }
+
+    @ParameterizedTest(name = "Children dobs={0}")
+    @MethodSource("provideArgumentsForChildrenFourAndOver")
+    void shouldReturnNoChildrenAtStartOrPaymentCycle(List<LocalDate> childrenDobs) {
+        //Given a children 4 or over 4 in the PaymentCycle
+        PaymentCycle paymentCycle = aPaymentCycleWithChildrenDobs(childrenDobs);
+        //When
+        boolean hasChildren = childDateOfBirthCalculator.hadChildrenUnder4AtStartOfPaymentCycle(paymentCycle);
+        //Then
+        assertThat(hasChildren).isFalse();
+    }
+
+    private static Stream<Arguments> provideArgumentsForChildrenFourAndOver() {
+        return Stream.of(
+                Arguments.of(emptyList()),
+                Arguments.of(List.of(LocalDate.now().minusYears(4))),
+                Arguments.of(List.of(LocalDate.now().minusYears(4).minusDays(1))),
+                Arguments.of(List.of(LocalDate.now().minusYears(5), LocalDate.now().minusYears(6))),
+                Arguments.of(List.of(LocalDate.now().minusYears(4).minusMonths(6)))
+        );
+    }
+
+    private static Stream<Arguments> provideArgumentsForChildrenUnderFour() {
+        return Stream.of(
+                Arguments.of(List.of(YOUNGEST_CHILD_DOB)),
+                Arguments.of(List.of(ELDEST_CHILD_DOB)),
+                Arguments.of(List.of(LocalDate.now().minusYears(4).plusDays(1))),
+                Arguments.of(List.of(YOUNGEST_CHILD_DOB, ELDEST_CHILD_DOB))
+        );
+    }
+
     private PaymentCycle buildPaymentCycleWithChildDobs(LocalDate... childDobs) {
-        return aValidPaymentCycleBuilder()
-                .childrenDob(List.of(childDobs))
-                .build();
+        return aPaymentCycleWithChildrenDobs(List.of(childDobs));
     }
 
 }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/PaymentCycleTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/PaymentCycleTestDataFactory.java
@@ -48,6 +48,20 @@ public class PaymentCycleTestDataFactory {
                 .build();
     }
 
+    public static PaymentCycle aPaymentCycleWithStartDateClaimAndExpectedDeliveryDate(LocalDate startDate,
+                                                                                      Claim claim,
+                                                                                      LocalDate expectedDeliveryDate) {
+        PaymentCycleVoucherEntitlement voucherEntitlement = aPaymentCycleVoucherEntitlementWithVouchersFromDate(startDate);
+        return aValidPaymentCycleBuilder()
+                .voucherEntitlement(voucherEntitlement)
+                .totalVouchers(voucherEntitlement.getTotalVoucherEntitlement())
+                .cycleStartDate(startDate)
+                .claim(claim)
+                .childrenDob(nullSafeGetChildrenDob(claim))
+                .expectedDeliveryDate(expectedDeliveryDate)
+                .build();
+    }
+
     public static PaymentCycle aPaymentCycleWithStartAndEndDate(LocalDate startDate, LocalDate endDate) {
         PaymentCycleVoucherEntitlement voucherEntitlement = aPaymentCycleVoucherEntitlementWithVouchersFromDate(startDate);
         return aValidPaymentCycleBuilder()
@@ -89,6 +103,10 @@ public class PaymentCycleTestDataFactory {
 
     public static PaymentCycle aPaymentCycleWithStatus(PaymentCycleStatus status) {
         return aValidPaymentCycleBuilder().paymentCycleStatus(status).build();
+    }
+
+    public static PaymentCycle aPaymentCycleWithChildrenDobs(List<LocalDate> childrenDobs) {
+        return aValidPaymentCycleBuilder().childrenDob(childrenDobs).build();
     }
 
     public static PaymentCycle.PaymentCycleBuilder aValidPaymentCycleBuilder() {


### PR DESCRIPTION
This method isn't currently used, but will be used by DetermineEntitlementMessageProcessor for HTBHF-2182 to check if they had children under 4 in the previous cycle.