### PR TITLE
HTBHF-2182 Make sure that the default Claimant is pregnant as this is…

### DIFF
--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/processor/ChildDateOfBirthCalculatorTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/processor/ChildDateOfBirthCalculatorTest.java
@@ -285,7 +285,7 @@ class ChildDateOfBirthCalculatorTest {
 
     @ParameterizedTest(name = "Children dobs={0}")
     @MethodSource("provideArgumentsForChildrenUnderFour")
-    void shouldReturnChildrenAtStartOrPaymentCycle(List<LocalDate> childrenDobs) {
+    void shouldReturnChildrenAtStartOfPaymentCycle(List<LocalDate> childrenDobs) {
         //Given a children under 4 in the PaymentCycle
         PaymentCycle paymentCycle = aPaymentCycleWithChildrenDobs(childrenDobs);
         //When
@@ -296,7 +296,7 @@ class ChildDateOfBirthCalculatorTest {
 
     @ParameterizedTest(name = "Children dobs={0}")
     @MethodSource("provideArgumentsForChildrenFourAndOver")
-    void shouldReturnNoChildrenAtStartOrPaymentCycle(List<LocalDate> childrenDobs) {
+    void shouldReturnNoChildrenAtStartOfPaymentCycle(List<LocalDate> childrenDobs) {
         //Given a children 4 or over 4 in the PaymentCycle
         PaymentCycle paymentCycle = aPaymentCycleWithChildrenDobs(childrenDobs);
         //When

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/processor/DetermineEntitlementMessageProcessorTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/processor/DetermineEntitlementMessageProcessorTest.java
@@ -43,13 +43,12 @@ import static uk.gov.dhsc.htbhf.claimant.testsupport.MessageContextTestDataFacto
 import static uk.gov.dhsc.htbhf.claimant.testsupport.MessageTestDataFactory.aValidMessageWithType;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aPaymentCycleWithClaim;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aPaymentCycleWithStartDateAndClaim;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.EXPECTED_DELIVERY_DATE;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.NOT_PREGNANT;
 import static uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus.ELIGIBLE;
 
 @ExtendWith(MockitoExtension.class)
 class DetermineEntitlementMessageProcessorTest {
-
-    private static final LocalDate EXPECTED_DELIVERY_DATE = LocalDate.now().plusMonths(2);
-    private static final LocalDate NOT_PREGNANT = null;
 
     @Mock
     private EligibilityAndEntitlementService eligibilityAndEntitlementService;

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/ClaimServiceTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/ClaimServiceTest.java
@@ -19,6 +19,7 @@ import uk.gov.dhsc.htbhf.claimant.reporting.ClaimAction;
 import uk.gov.dhsc.htbhf.claimant.repository.ClaimRepository;
 import uk.gov.dhsc.htbhf.claimant.service.audit.ClaimEventType;
 import uk.gov.dhsc.htbhf.claimant.service.audit.EventAuditor;
+import uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants;
 import uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus;
 import uk.gov.dhsc.htbhf.logging.event.CommonEventType;
 import uk.gov.dhsc.htbhf.logging.event.FailureEvent;
@@ -226,9 +227,8 @@ class ClaimServiceTest {
     @Test
     void shouldUpdateClaimAndReturnClaimUpdatedForMatchingNinoWhenEligibleAndNoFieldsHaveChanged() {
         //given
-        LocalDate expectedDeliveryDate = LocalDate.now().plusMonths(6);
-        Claimant existingClaimant = aClaimantWithExpectedDeliveryDate(expectedDeliveryDate);
-        Claimant newClaimant = aClaimantWithExpectedDeliveryDate(expectedDeliveryDate);
+        Claimant existingClaimant = aValidClaimant();
+        Claimant newClaimant = aValidClaimant();
         Claim existingClaim = aClaimWithClaimant(existingClaimant);
         UUID existingClaimId = UUID.randomUUID();
         EligibilityAndEntitlementDecision decision = EligibilityAndEntitlementDecision.builder()
@@ -247,7 +247,7 @@ class ClaimServiceTest {
         assertThat(result.getClaimUpdated()).isTrue();
         assertThat(result.getUpdatedFields()).isEmpty();
         assertThat(result.getClaim()).isEqualTo(existingClaim);
-        assertThat(result.getClaim().getClaimant().getExpectedDeliveryDate()).isEqualTo(expectedDeliveryDate);
+        assertThat(result.getClaim().getClaimant().getExpectedDeliveryDate()).isEqualTo(TestConstants.EXPECTED_DELIVERY_DATE);
         verify(eligibilityAndEntitlementService).evaluateClaimant(newClaimant);
         verify(claimRepository).findClaim(existingClaimId);
         verify(claimRepository).save(result.getClaim());

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/ClaimantTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/ClaimantTestDataFactory.java
@@ -79,7 +79,8 @@ public final class ClaimantTestDataFactory {
                 .dateOfBirth(VALID_DOB)
                 .phoneNumber(VALID_PHONE_NUMBER)
                 .emailAddress(VALID_EMAIL_ADDRESS)
-                .address(aValidAddress());
+                .address(aValidAddress())
+                .expectedDeliveryDate(EXPECTED_DELIVERY_DATE);
     }
 
     public static Claimant.ClaimantBuilder aValidClaimantInSameHouseholdBuilder() {

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/PaymentCycleTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/PaymentCycleTestDataFactory.java
@@ -33,6 +33,7 @@ public class PaymentCycleTestDataFactory {
                 .totalVouchers(paymentCycleVoucherEntitlement.getTotalVoucherEntitlement())
                 .claim(claim)
                 .childrenDob(nullSafeGetChildrenDob(claim))
+                .expectedDeliveryDate(nullSafeGetExpectedDeliveryDate(claim))
                 .build();
     }
 
@@ -45,12 +46,12 @@ public class PaymentCycleTestDataFactory {
                 .cycleStartDate(startDate)
                 .claim(claim)
                 .childrenDob(nullSafeGetChildrenDob(claim))
+                .expectedDeliveryDate(nullSafeGetExpectedDeliveryDate(claim))
                 .build();
     }
 
     public static PaymentCycle aPaymentCycleWithStartDateClaimAndExpectedDeliveryDate(LocalDate startDate,
-                                                                                      Claim claim,
-                                                                                      LocalDate expectedDeliveryDate) {
+                                                                                      Claim claim) {
         PaymentCycleVoucherEntitlement voucherEntitlement = aPaymentCycleVoucherEntitlementWithVouchersFromDate(startDate);
         return aValidPaymentCycleBuilder()
                 .voucherEntitlement(voucherEntitlement)
@@ -58,7 +59,7 @@ public class PaymentCycleTestDataFactory {
                 .cycleStartDate(startDate)
                 .claim(claim)
                 .childrenDob(nullSafeGetChildrenDob(claim))
-                .expectedDeliveryDate(expectedDeliveryDate)
+                .expectedDeliveryDate(nullSafeGetExpectedDeliveryDate(claim))
                 .build();
     }
 
@@ -89,6 +90,7 @@ public class PaymentCycleTestDataFactory {
         PaymentCycle paymentCycle = aValidPaymentCycleBuilder()
                 .claim(claim)
                 .childrenDob(nullSafeGetChildrenDob(claim))
+                .expectedDeliveryDate(nullSafeGetExpectedDeliveryDate(claim))
                 .build();
         paymentCycle.addPayment(payment);
         return paymentCycle;
@@ -98,6 +100,7 @@ public class PaymentCycleTestDataFactory {
         return aValidPaymentCycleBuilder()
                 .claim(claim)
                 .childrenDob(nullSafeGetChildrenDob(claim))
+                .expectedDeliveryDate(nullSafeGetExpectedDeliveryDate(claim))
                 .build();
     }
 
@@ -111,8 +114,9 @@ public class PaymentCycleTestDataFactory {
 
     public static PaymentCycle.PaymentCycleBuilder aValidPaymentCycleBuilder() {
         PaymentCycleVoucherEntitlement voucherEntitlement = aPaymentCycleVoucherEntitlementWithVouchers();
+        Claim claim = aValidClaim();
         return PaymentCycle.builder()
-                .claim(aValidClaim())
+                .claim(claim)
                 .paymentCycleStatus(NEW)
                 .eligibilityStatus(EligibilityStatus.ELIGIBLE)
                 .voucherEntitlement(voucherEntitlement)
@@ -124,10 +128,15 @@ public class PaymentCycleTestDataFactory {
                 .childrenDob(List.of(
                         LocalDate.now().minusMonths(6),
                         LocalDate.now().minusYears(3).minusMonths(6)))
-                .totalEntitlementAmountInPence(TOTAL_ENTITLEMENT_AMOUNT_IN_PENCE);
+                .totalEntitlementAmountInPence(TOTAL_ENTITLEMENT_AMOUNT_IN_PENCE)
+                .expectedDeliveryDate(claim.getClaimant().getExpectedDeliveryDate());
     }
 
     private static List<LocalDate> nullSafeGetChildrenDob(Claim claim) {
         return (claim == null) ? emptyList() : claim.getClaimant().getChildrenDob();
+    }
+
+    private static LocalDate nullSafeGetExpectedDeliveryDate(Claim claim) {
+        return (claim == null) ? null : claim.getClaimant().getExpectedDeliveryDate();
     }
 }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/TestConstants.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/TestConstants.java
@@ -35,6 +35,8 @@ public class TestConstants {
 
     public static final LocalDate MAGGIE_DOB = LocalDate.now().minusMonths(6);
     public static final LocalDate LISA_DOB = LocalDate.now().minusMonths(24);
+    public static final LocalDate EXPECTED_DELIVERY_DATE = LocalDate.now().plusMonths(2);
+    public static final LocalDate NOT_PREGNANT = null;
 
     public static final String CARD_ACCOUNT_ID = "123456789";
 


### PR DESCRIPTION
… the majority of its usage. Also make sure that the expected delivery date is set on any PaymentCycle built from the Claimant provided in the test data factory.

The existing PaymentCycles were building a voucher entitlement that had vouchers for pregnancy but the Claimant being used didn't have an expected delivery date. This PR attempts to fix that and make sure that the expected delivery date is what's used on the PaymentCycle too.