### PR TITLE
HTBHF-2182 Fix bug in PaymentCycleService were it was only setting the…

### DIFF
--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/processor/DetermineEntitlementMessageProcessorTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/processor/DetermineEntitlementMessageProcessorTest.java
@@ -43,7 +43,7 @@ import static uk.gov.dhsc.htbhf.claimant.testsupport.MessageContextTestDataFacto
 import static uk.gov.dhsc.htbhf.claimant.testsupport.MessageTestDataFactory.aValidMessageWithType;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aPaymentCycleWithClaim;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aPaymentCycleWithStartDateAndClaim;
-import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.EXPECTED_DELIVERY_DATE;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.NOT_PREGNANT;
 import static uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus.ELIGIBLE;
 
@@ -71,7 +71,7 @@ class DetermineEntitlementMessageProcessorTest {
     @Test
     void shouldSuccessfullyProcessMessageAndTriggerPaymentWhenClaimantIsEligible() {
         //Given
-        DetermineEntitlementMessageContext context = buildMessageContext(EXPECTED_DELIVERY_DATE);
+        DetermineEntitlementMessageContext context = buildMessageContext(EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS);
         given(messageContextLoader.loadDetermineEntitlementContext(any())).willReturn(context);
 
         //Eligibility

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/ClaimServiceTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/ClaimServiceTest.java
@@ -19,7 +19,6 @@ import uk.gov.dhsc.htbhf.claimant.reporting.ClaimAction;
 import uk.gov.dhsc.htbhf.claimant.repository.ClaimRepository;
 import uk.gov.dhsc.htbhf.claimant.service.audit.ClaimEventType;
 import uk.gov.dhsc.htbhf.claimant.service.audit.EventAuditor;
-import uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants;
 import uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus;
 import uk.gov.dhsc.htbhf.logging.event.CommonEventType;
 import uk.gov.dhsc.htbhf.logging.event.FailureEvent;
@@ -50,6 +49,7 @@ import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimantTestDataFactory.aCl
 import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimantTestDataFactory.aValidClaimant;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.EligibilityAndEntitlementTestDataFactory.aDecisionWithStatus;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementWithVouchers;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.TEST_EXCEPTION;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.VoucherEntitlementTestDataFactory.aVoucherEntitlementWithEntitlementDate;
 import static uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus.ELIGIBLE;
@@ -247,7 +247,7 @@ class ClaimServiceTest {
         assertThat(result.getClaimUpdated()).isTrue();
         assertThat(result.getUpdatedFields()).isEmpty();
         assertThat(result.getClaim()).isEqualTo(existingClaim);
-        assertThat(result.getClaim().getClaimant().getExpectedDeliveryDate()).isEqualTo(TestConstants.EXPECTED_DELIVERY_DATE);
+        assertThat(result.getClaim().getClaimant().getExpectedDeliveryDate()).isEqualTo(EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS);
         verify(eligibilityAndEntitlementService).evaluateClaimant(newClaimant);
         verify(claimRepository).findClaim(existingClaimId);
         verify(claimRepository).save(result.getClaim());

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/ClaimantTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/ClaimantTestDataFactory.java
@@ -80,7 +80,7 @@ public final class ClaimantTestDataFactory {
                 .phoneNumber(VALID_PHONE_NUMBER)
                 .emailAddress(VALID_EMAIL_ADDRESS)
                 .address(aValidAddress())
-                .expectedDeliveryDate(EXPECTED_DELIVERY_DATE);
+                .expectedDeliveryDate(EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS);
     }
 
     public static Claimant.ClaimantBuilder aValidClaimantInSameHouseholdBuilder() {

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/TestConstants.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/TestConstants.java
@@ -35,7 +35,8 @@ public class TestConstants {
 
     public static final LocalDate MAGGIE_DOB = LocalDate.now().minusMonths(6);
     public static final LocalDate LISA_DOB = LocalDate.now().minusMonths(24);
-    public static final LocalDate EXPECTED_DELIVERY_DATE = LocalDate.now().plusMonths(2);
+    public static final LocalDate EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS = LocalDate.now().plusMonths(2);
+    public static final LocalDate EXPECTED_DELIVERY_DATE_TOO_FAR_IN_PAST = LocalDate.now().minusWeeks(13);
     public static final LocalDate NOT_PREGNANT = null;
 
     public static final String CARD_ACCOUNT_ID = "123456789";


### PR DESCRIPTION
…expected delivery date if there are no vouchers, but we need to be setting it whenever its an eligible date irrespective of the number of vouchers.

We need to know whether they are considered pregnant or not for this cycle as it is used to determine which scenario we are in for the DetermineEntitlementMessageProcessor.