### PR TITLE
HTBHF-2012 Create report payment event properties.

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/context/MessageContextLoader.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/context/MessageContextLoader.java
@@ -130,11 +130,14 @@ public class MessageContextLoader {
     public ReportPaymentMessageContext loadReportPaymentMessageContext(Message message) {
         ReportPaymentMessagePayload payload = payloadMapper.getPayload(message, ReportPaymentMessagePayload.class);
         Claim claim = getAndCheckClaim(payload.getClaimId());
-        Optional<PaymentCycle> paymentCycle = payload.getPaymentCycleId().flatMap(id -> paymentCycleRepository.findById(id));
+        PaymentCycle paymentCycle = getAndCheckPaymentCycle(payload.getPaymentCycleId(), "payment cycle");
 
         return ReportPaymentMessageContext.builder()
                 .claim(claim)
                 .paymentCycle(paymentCycle)
+                .paymentForPregnancy(payload.getPaymentForPregnancy())
+                .paymentForChildrenUnderOne(payload.getPaymentForChildrenUnderOne())
+                .paymentForChildrenBetweenOneAndFour(payload.getPaymentForChildrenBetweenOneAndFour())
                 .datesOfBirthOfChildren(payload.getDatesOfBirthOfChildren())
                 .paymentAction(payload.getPaymentAction())
                 .timestamp(payload.getTimestamp())

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/context/ReportClaimMessageContext.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/context/ReportClaimMessageContext.java
@@ -1,20 +1,19 @@
 package uk.gov.dhsc.htbhf.claimant.message.context;
 
-import lombok.Builder;
-import lombok.Value;
-import uk.gov.dhsc.htbhf.claimant.entity.Claim;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
 import uk.gov.dhsc.htbhf.claimant.reporting.ClaimAction;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
+@Data
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+public class ReportClaimMessageContext extends ReportEventMessageContext {
 
-@Value
-@Builder
-public class ReportClaimMessageContext {
-
-    private Claim claim;
-    private List<LocalDate> datesOfBirthOfChildren;
     private ClaimAction claimAction;
-    private LocalDateTime timestamp;
+
+    @Override
+    public String getEventAction() {
+        return claimAction.name();
+    }
 }

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/context/ReportEventMessageContext.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/context/ReportEventMessageContext.java
@@ -1,0 +1,20 @@
+package uk.gov.dhsc.htbhf.claimant.message.context;
+
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+import uk.gov.dhsc.htbhf.claimant.entity.Claim;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@SuperBuilder
+public abstract class ReportEventMessageContext {
+
+    private Claim claim;
+    private List<LocalDate> datesOfBirthOfChildren;
+    private LocalDateTime timestamp;
+
+    public abstract String getEventAction();
+}

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/context/ReportPaymentMessageContext.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/context/ReportPaymentMessageContext.java
@@ -1,22 +1,23 @@
 package uk.gov.dhsc.htbhf.claimant.message.context;
 
-import lombok.Builder;
-import lombok.Value;
-import uk.gov.dhsc.htbhf.claimant.entity.Claim;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
 import uk.gov.dhsc.htbhf.claimant.entity.PaymentCycle;
 import uk.gov.dhsc.htbhf.claimant.reporting.PaymentAction;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-
-@Value
-@Builder
-public class ReportPaymentMessageContext {
-    private Claim claim;
-    private Optional<PaymentCycle> paymentCycle;
-    private List<LocalDate> datesOfBirthOfChildren;
+@Data
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+public class ReportPaymentMessageContext extends ReportEventMessageContext {
+    private PaymentCycle paymentCycle;
     private PaymentAction paymentAction;
-    private LocalDateTime timestamp;
+    private int paymentForPregnancy;
+    private int paymentForChildrenUnderOne;
+    private int paymentForChildrenBetweenOneAndFour;
+
+    @Override
+    public String getEventAction() {
+        return paymentAction.name();
+    }
 }

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/payload/ReportPaymentMessagePayload.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/payload/ReportPaymentMessagePayload.java
@@ -7,15 +7,17 @@ import uk.gov.dhsc.htbhf.claimant.reporting.PaymentAction;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 @Data
 @Builder
 public class ReportPaymentMessagePayload implements MessagePayload {
     private UUID claimId;
-    private Optional<UUID> paymentCycleId;
+    private UUID paymentCycleId;
     private List<LocalDate> datesOfBirthOfChildren;
     private PaymentAction paymentAction;
+    private int paymentForPregnancy;
+    private int paymentForChildrenUnderOne;
+    private int paymentForChildrenBetweenOneAndFour;
     private LocalDateTime timestamp;
 }

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/processor/NextPaymentCycleSummary.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/processor/NextPaymentCycleSummary.java
@@ -30,4 +30,8 @@ public class NextPaymentCycleSummary {
     public boolean hasMultipleChildrenTurningOne() {
         return numberOfChildrenTurningOne > 1;
     }
+
+    public int getNumberOfChildrenTurningOneOrFour() {
+        return numberOfChildrenTurningOne + numberOfChildrenTurningFour;
+    }
 }

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/reporting/payload/ReportPropertiesFactory.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/reporting/payload/ReportPropertiesFactory.java
@@ -2,8 +2,14 @@ package uk.gov.dhsc.htbhf.claimant.reporting.payload;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import uk.gov.dhsc.htbhf.claimant.entitlement.PaymentCycleVoucherEntitlement;
 import uk.gov.dhsc.htbhf.claimant.entity.Claimant;
+import uk.gov.dhsc.htbhf.claimant.entity.PaymentCycle;
 import uk.gov.dhsc.htbhf.claimant.message.context.ReportClaimMessageContext;
+import uk.gov.dhsc.htbhf.claimant.message.context.ReportEventMessageContext;
+import uk.gov.dhsc.htbhf.claimant.message.context.ReportPaymentMessageContext;
+import uk.gov.dhsc.htbhf.claimant.message.processor.ChildDateOfBirthCalculator;
+import uk.gov.dhsc.htbhf.claimant.message.processor.NextPaymentCycleSummary;
 import uk.gov.dhsc.htbhf.claimant.model.PostcodeData;
 import uk.gov.dhsc.htbhf.claimant.reporting.ClaimantCategoryCalculator;
 
@@ -19,6 +25,7 @@ import java.util.TreeMap;
 import static uk.gov.dhsc.htbhf.claimant.reporting.payload.CustomDimension.*;
 import static uk.gov.dhsc.htbhf.claimant.reporting.payload.CustomMetric.*;
 import static uk.gov.dhsc.htbhf.claimant.reporting.payload.EventCategory.CLAIM;
+import static uk.gov.dhsc.htbhf.claimant.reporting.payload.EventCategory.PAYMENT;
 import static uk.gov.dhsc.htbhf.claimant.reporting.payload.EventProperties.*;
 import static uk.gov.dhsc.htbhf.claimant.reporting.payload.MandatoryProperties.HIT_TYPE_KEY;
 import static uk.gov.dhsc.htbhf.claimant.reporting.payload.MandatoryProperties.PROTOCOL_VERSION_KEY;
@@ -29,6 +36,7 @@ import static uk.gov.dhsc.htbhf.claimant.reporting.payload.UserType.ONLINE;
  * Factory class for creating a map of parameters reported to google analytics measurement protocol.
  */
 @Component
+@SuppressWarnings("PMD.TooManyMethods")
 public class ReportPropertiesFactory {
 
     private static final String HIT_TYPE_VALUE = "event";
@@ -39,20 +47,33 @@ public class ReportPropertiesFactory {
     public static final int PREGNANCY_DURATION_IN_WEEKS = 40;
 
     private final ClaimantCategoryCalculator claimantCategoryCalculator;
+    private final ChildDateOfBirthCalculator childDateOfBirthCalculator;
     private final String trackingId;
 
     public ReportPropertiesFactory(@Value("${google-analytics.tracking-id}") String trackingId,
-                                   ClaimantCategoryCalculator claimantCategoryCalculator) {
+                                   ClaimantCategoryCalculator claimantCategoryCalculator,
+                                   ChildDateOfBirthCalculator childDateOfBirthCalculator) {
         this.trackingId = trackingId;
         this.claimantCategoryCalculator = claimantCategoryCalculator;
+        this.childDateOfBirthCalculator = childDateOfBirthCalculator;
     }
 
     public Map<String, String> createReportPropertiesForClaimEvent(ReportClaimMessageContext context) {
         Map<String, String> reportProperties = new LinkedHashMap<>();
         reportProperties.putAll(mapValuesToString(createMandatoryPropertiesMap()));
-        reportProperties.putAll(mapValuesToString(createEventPropertiesMap(context)));
+        reportProperties.putAll(mapValuesToString(createEventPropertiesMap(context, CLAIM, 0)));
         reportProperties.putAll(mapValuesToString(createCustomDimensionMap(context)));
-        reportProperties.putAll(mapValuesToString(createCustomMetricMap(context)));
+        reportProperties.putAll(mapValuesToString(createCustomMetricMapForClaimEvent(context)));
+        return reportProperties;
+    }
+
+    public Map<String, String> createReportPropertiesForPaymentEvent(ReportPaymentMessageContext context) {
+        Map<String, String> reportProperties = new LinkedHashMap<>();
+        reportProperties.putAll(mapValuesToString(createMandatoryPropertiesMap()));
+        int totalPaymentAmount = context.getPaymentForPregnancy() + context.getPaymentForChildrenUnderOne() + context.getPaymentForChildrenBetweenOneAndFour();
+        reportProperties.putAll(mapValuesToString(createEventPropertiesMap(context, PAYMENT, totalPaymentAmount)));
+        reportProperties.putAll(mapValuesToString(createCustomDimensionMap(context)));
+        reportProperties.putAll(mapValuesToString(createCustomMetricMapForPaymentEvent(context)));
         return reportProperties;
     }
 
@@ -64,17 +85,17 @@ public class ReportPropertiesFactory {
         return mandatoryProperties;
     }
 
-    private Map<String, Object> createEventPropertiesMap(ReportClaimMessageContext context) {
+    private Map<String, Object> createEventPropertiesMap(ReportEventMessageContext context, EventCategory eventCategory, int eventValue) {
         Map<String, Object> eventPropertiesMap = new LinkedHashMap<>();
-        eventPropertiesMap.put(EVENT_CATEGORY.getFieldName(), CLAIM.name());
-        eventPropertiesMap.put(EVENT_ACTION.getFieldName(), context.getClaimAction().name());
-        eventPropertiesMap.put(EVENT_VALUE.getFieldName(), 0);
+        eventPropertiesMap.put(EVENT_CATEGORY.getFieldName(), eventCategory.name());
+        eventPropertiesMap.put(EVENT_ACTION.getFieldName(), context.getEventAction());
+        eventPropertiesMap.put(EVENT_VALUE.getFieldName(), eventValue);
         eventPropertiesMap.put(QUEUE_TIME.getFieldName(), calculateQueueTime(context.getTimestamp()));
         eventPropertiesMap.put(CUSTOMER_ID.getFieldName(), context.getClaim().getId());
         return eventPropertiesMap;
     }
 
-    private Map<String, Object> createCustomDimensionMap(ReportClaimMessageContext context) {
+    private Map<String, Object> createCustomDimensionMap(ReportEventMessageContext context) {
         Map<String, Object> customDimensions = new TreeMap<>();
         customDimensions.put(USER_TYPE.getFieldName(), ONLINE.name());
         ClaimantCategory claimantCategory = claimantCategoryCalculator
@@ -91,7 +112,24 @@ public class ReportPropertiesFactory {
         return customDimensions;
     }
 
-    private Map<String, Object> createCustomMetricMap(ReportClaimMessageContext context) {
+    private Map<String, Object> createCustomMetricMapForClaimEvent(ReportClaimMessageContext context) {
+        Map<String, Object> customMetrics = createCommonCustomMetrics(context);
+        LocalDate expectedDeliveryDate = context.getClaim().getClaimant().getExpectedDeliveryDate();
+        LocalDate atDate = context.getTimestamp().toLocalDate();
+        if (isClaimantPregnant(expectedDeliveryDate, atDate)) {
+            LocalDate conception = expectedDeliveryDate.minusWeeks(PREGNANCY_DURATION_IN_WEEKS);
+            customMetrics.put(WEEKS_PREGNANT.getFieldName(), ChronoUnit.WEEKS.between(conception, atDate));
+        }
+        return customMetrics;
+    }
+
+    private Map<String, Object> createCustomMetricMapForPaymentEvent(ReportPaymentMessageContext context) {
+        Map<String, Object> customMetrics = createCommonCustomMetrics(context);
+        addPaymentCycleMetrics(context, customMetrics);
+        return customMetrics;
+    }
+
+    private Map<String, Object> createCommonCustomMetrics(ReportEventMessageContext context) {
         Map<String, Object> customMetrics = new TreeMap<>();
         Claimant claimant = context.getClaim().getClaimant();
         LocalDate atDate = context.getTimestamp().toLocalDate();
@@ -101,14 +139,23 @@ public class ReportPropertiesFactory {
         customMetrics.put(CHILDREN_UNDER_ONE.getFieldName(), childrenUnder1);
         customMetrics.put(CHILDREN_BETWEEN_ONE_AND_FOUR.getFieldName(), childrenUnder4 - childrenUnder1);
         LocalDate expectedDeliveryDate = claimant.getExpectedDeliveryDate();
-        if (expectedDeliveryDate == null || expectedDeliveryDate.isBefore(atDate)) {
-            customMetrics.put(PREGNANCIES.getFieldName(), 0);
-        } else {
-            customMetrics.put(PREGNANCIES.getFieldName(), 1);
-            LocalDate conception = expectedDeliveryDate.minusWeeks(PREGNANCY_DURATION_IN_WEEKS);
-            customMetrics.put(WEEKS_PREGNANT.getFieldName(), ChronoUnit.WEEKS.between(conception, atDate));
-        }
+        int pregnanciesValue = isClaimantPregnant(expectedDeliveryDate, atDate) ? 1 : 0;
+        customMetrics.put(PREGNANCIES.getFieldName(), pregnanciesValue);
         return customMetrics;
+    }
+
+    private boolean isClaimantPregnant(LocalDate expectedDeliveryDate, LocalDate atDate) {
+        return expectedDeliveryDate != null && !expectedDeliveryDate.isBefore(atDate);
+    }
+
+    private void addPaymentCycleMetrics(ReportPaymentMessageContext context, Map<String, Object> customMetrics) {
+        PaymentCycle paymentCycle = context.getPaymentCycle();
+        PaymentCycleVoucherEntitlement voucherEntitlement = paymentCycle.getVoucherEntitlement();
+        customMetrics.put(PAYMENT_FOR_PREGNANCY.getFieldName(), context.getPaymentForPregnancy());
+        customMetrics.put(PAYMENT_FOR_CHILDREN_UNDER_ONE.getFieldName(), context.getPaymentForChildrenUnderOne());
+        customMetrics.put(PAYMENT_FOR_CHILDREN_BETWEEN_ONE_AND_FOUR.getFieldName(), context.getPaymentForChildrenBetweenOneAndFour());
+        NextPaymentCycleSummary nextPaymentCycleSummary = childDateOfBirthCalculator.getNextPaymentCycleSummary(paymentCycle);
+        customMetrics.put(NUMBER_OF_1ST_OR_FOURTH_BIRTHDAYS_IN_NEXT_CYCLE.getFieldName(), nextPaymentCycleSummary.getNumberOfChildrenTurningOneOrFour());
     }
 
     private Long calculateQueueTime(LocalDateTime timestamp) {

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/context/MessageContextLoaderTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/context/MessageContextLoaderTest.java
@@ -445,8 +445,11 @@ class MessageContextLoaderTest {
         ReportPaymentMessagePayload payload = ReportPaymentMessagePayload.builder()
                 .claimId(claim.getId())
                 .paymentAction(PaymentAction.INITIAL_PAYMENT)
-                .paymentCycleId(Optional.of(paymentCycle.getId()))
+                .paymentCycleId(paymentCycle.getId())
                 .datesOfBirthOfChildren(SINGLE_THREE_YEAR_OLD)
+                .paymentForPregnancy(100)
+                .paymentForChildrenUnderOne(100)
+                .paymentForChildrenBetweenOneAndFour(100)
                 .timestamp(LocalDateTime.now())
                 .build();
         given(claimRepository.findById(any())).willReturn(Optional.of(claim));
@@ -458,41 +461,15 @@ class MessageContextLoaderTest {
 
         //Then
         assertThat(context.getClaim()).isEqualTo(claim);
-        assertThat(context.getPaymentCycle()).contains(paymentCycle);
+        assertThat(context.getPaymentCycle()).isEqualTo(paymentCycle);
         assertThat(context.getDatesOfBirthOfChildren()).isEqualTo(payload.getDatesOfBirthOfChildren());
         assertThat(context.getTimestamp()).isEqualTo(payload.getTimestamp());
         assertThat(context.getPaymentAction()).isEqualTo(payload.getPaymentAction());
+        assertThat(context.getPaymentForPregnancy()).isEqualTo(100);
+        assertThat(context.getPaymentForChildrenUnderOne()).isEqualTo(100);
+        assertThat(context.getPaymentForChildrenBetweenOneAndFour()).isEqualTo(100);
         verify(payloadMapper).getPayload(message, ReportPaymentMessagePayload.class);
         verify(claimRepository).findById(claim.getId());
         verify(paymentCycleRepository).findById(paymentCycle.getId());
-    }
-
-    @Test
-    void shouldSuccessfullyLoadReportPaymentMessageContextWithoutAPaymentCycle() {
-        //Given
-        Claim claim = aValidClaim();
-        Message message = aValidMessageWithType(REPORT_PAYMENT);
-        ReportPaymentMessagePayload payload = ReportPaymentMessagePayload.builder()
-                .claimId(claim.getId())
-                .paymentAction(PaymentAction.INITIAL_PAYMENT)
-                .paymentCycleId(Optional.empty())
-                .datesOfBirthOfChildren(SINGLE_THREE_YEAR_OLD)
-                .timestamp(LocalDateTime.now())
-                .build();
-        given(claimRepository.findById(any())).willReturn(Optional.of(claim));
-        given(payloadMapper.getPayload(message, ReportPaymentMessagePayload.class)).willReturn(payload);
-
-        //When
-        ReportPaymentMessageContext context = loader.loadReportPaymentMessageContext(message);
-
-        //Then
-        assertThat(context.getClaim()).isEqualTo(claim);
-        assertThat(context.getPaymentCycle()).isEmpty();
-        assertThat(context.getDatesOfBirthOfChildren()).isEqualTo(payload.getDatesOfBirthOfChildren());
-        assertThat(context.getTimestamp()).isEqualTo(payload.getTimestamp());
-        assertThat(context.getPaymentAction()).isEqualTo(payload.getPaymentAction());
-        verify(payloadMapper).getPayload(message, ReportPaymentMessagePayload.class);
-        verify(claimRepository).findById(claim.getId());
-        verifyZeroInteractions(paymentCycleRepository);
     }
 }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/processor/NextPaymentCycleSummaryTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/processor/NextPaymentCycleSummaryTest.java
@@ -57,4 +57,18 @@ class NextPaymentCycleSummaryTest {
         assertThat(NO_CHILDREN.hasMultipleChildrenTurningFour()).isFalse();
     }
 
+    @ParameterizedTest
+    @CsvSource({
+            "0, 0, 0",
+            "1, 1, 2",
+            "3, 2, 5"
+    })
+    void testNumberOfChildrenTurningOneOrFour(int childrenTuringOne, int childrenTurningFour, int total) {
+        NextPaymentCycleSummary summary = NextPaymentCycleSummary.builder()
+                .numberOfChildrenTurningOne(childrenTuringOne)
+                .numberOfChildrenTurningFour(childrenTurningFour)
+                .build();
+
+        assertThat(summary.getNumberOfChildrenTurningOneOrFour()).isEqualTo(total);
+    }
 }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/ClaimTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/ClaimTestDataFactory.java
@@ -10,10 +10,13 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimantTestDataFactory.aClaimantWithExpectedDeliveryDate;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimantTestDataFactory.aValidClaimant;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.PostcodeDataTestDataFactory.aPostcodeDataObjectForPostcode;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.CARD_ACCOUNT_ID;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.DWP_HOUSEHOLD_IDENTIFIER;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.HMRC_HOUSEHOLD_IDENTIFIER;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.VALID_POSTCODE;
 
 public class ClaimTestDataFactory {
 
@@ -69,6 +72,14 @@ public class ClaimTestDataFactory {
     public static Claim aClaimWithPostcodeData(PostcodeData postcodeData) {
         return aValidClaimBuilder()
                 .postcodeData(postcodeData)
+                .build();
+    }
+
+    public static Claim aClaimWithDueDateAndPostcodeData(LocalDate expectedDeliveryDate) {
+        Claimant claimant = aClaimantWithExpectedDeliveryDate(expectedDeliveryDate);
+        return aValidClaimBuilder()
+                .claimant(claimant)
+                .postcodeData(aPostcodeDataObjectForPostcode(VALID_POSTCODE))
                 .build();
     }
 


### PR DESCRIPTION
- Creating report properties for payment events
- Added ReportEventMessageContext base class to reduce duplicate code.
- Added numberOfChildrenTurningOneOrFour() to NextPaymentCycleSummary.
- PaymentCycle is no longer optional as it will always be set by the caller.
- Added payment amount fields to the message as the payment cycle won't always be used to get the payment amount, as is the case for additional pregnancy payments.