### PR TITLE
NOJIRA Allow the bootrun task to accept command line system properties.

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -149,3 +149,6 @@ javadoc {
     failOnError = true
 }
 
+bootRun {
+    systemProperties System.properties
+}


### PR DESCRIPTION
Enabled the setting of system properties from the command line when running the gradle bootRun task. E.g. `./gradlew -Dgoogle-analytics.tracking-id=test-id bootRun`.
This is required for running from the command line now as the property `google-analytics.tracking-id` can not be set as an environment variable due to it containing a hyphen.