### PR TITLE
HTBHF-2011 Split report properties into two separate classes, one for…

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/reporting/MIReporter.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/reporting/MIReporter.java
@@ -8,7 +8,8 @@ import uk.gov.dhsc.htbhf.claimant.message.context.ReportClaimMessageContext;
 import uk.gov.dhsc.htbhf.claimant.message.context.ReportEventMessageContext;
 import uk.gov.dhsc.htbhf.claimant.message.context.ReportPaymentMessageContext;
 import uk.gov.dhsc.htbhf.claimant.model.PostcodeData;
-import uk.gov.dhsc.htbhf.claimant.reporting.payload.ReportPropertiesFactory;
+import uk.gov.dhsc.htbhf.claimant.reporting.payload.ReportClaimPropertiesFactory;
+import uk.gov.dhsc.htbhf.claimant.reporting.payload.ReportPaymentPropertiesFactory;
 import uk.gov.dhsc.htbhf.claimant.repository.ClaimRepository;
 
 import java.util.Map;
@@ -24,18 +25,19 @@ public class MIReporter {
 
     private final ClaimRepository claimRepository;
     private final PostcodeDataClient postcodeDataClient;
-    private final ReportPropertiesFactory reportPropertiesFactory;
+    private final ReportClaimPropertiesFactory reportClaimPropertiesFactory;
+    private final ReportPaymentPropertiesFactory reportPaymentPropertiesFactory;
     private final GoogleAnalyticsClient googleAnalyticsClient;
 
     public void reportClaim(ReportClaimMessageContext context) {
         updateClaimWithPostcodeDataIfNecessary(context);
-        Map<String, String> reportProperties = reportPropertiesFactory.createReportPropertiesForClaimEvent(context);
+        Map<String, String> reportProperties = reportClaimPropertiesFactory.createReportPropertiesForClaimEvent(context);
         googleAnalyticsClient.reportEvent(reportProperties);
     }
 
     public void reportPayment(ReportPaymentMessageContext context) {
         updateClaimWithPostcodeDataIfNecessary(context);
-        Map<String, String> reportProperties = reportPropertiesFactory.createReportPropertiesForPaymentEvent(context);
+        Map<String, String> reportProperties = reportPaymentPropertiesFactory.createReportPropertiesForPaymentEvent(context);
         googleAnalyticsClient.reportEvent(reportProperties);
     }
 

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/reporting/payload/ReportClaimPropertiesFactory.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/reporting/payload/ReportClaimPropertiesFactory.java
@@ -1,0 +1,46 @@
+package uk.gov.dhsc.htbhf.claimant.reporting.payload;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import uk.gov.dhsc.htbhf.claimant.message.context.ReportClaimMessageContext;
+import uk.gov.dhsc.htbhf.claimant.reporting.ClaimantCategoryCalculator;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static uk.gov.dhsc.htbhf.claimant.reporting.payload.CustomMetric.WEEKS_PREGNANT;
+import static uk.gov.dhsc.htbhf.claimant.reporting.payload.EventCategory.CLAIM;
+
+/**
+ * Factory class for creating a map of parameters for claims reported to google analytics measurement protocol.
+ */
+@Component
+public class ReportClaimPropertiesFactory extends ReportPropertiesFactory {
+
+    public ReportClaimPropertiesFactory(@Value("${google-analytics.tracking-id}") String trackingId,
+                                        ClaimantCategoryCalculator claimantCategoryCalculator) {
+        super(trackingId, claimantCategoryCalculator);
+    }
+
+    public Map<String, String> createReportPropertiesForClaimEvent(ReportClaimMessageContext context) {
+        Map<String, String> reportProperties = new LinkedHashMap<>();
+        reportProperties.putAll(mapValuesToString(createMandatoryPropertiesMap()));
+        reportProperties.putAll(mapValuesToString(createEventPropertiesMap(context, CLAIM, 0)));
+        reportProperties.putAll(mapValuesToString(createCustomDimensionMap(context)));
+        reportProperties.putAll(mapValuesToString(createCustomMetricMapForClaimEvent(context)));
+        return reportProperties;
+    }
+
+    private Map<String, Object> createCustomMetricMapForClaimEvent(ReportClaimMessageContext context) {
+        Map<String, Object> customMetrics = createCommonCustomMetrics(context);
+        LocalDate expectedDeliveryDate = context.getClaim().getClaimant().getExpectedDeliveryDate();
+        LocalDate atDate = context.getTimestamp().toLocalDate();
+        if (isClaimantPregnant(expectedDeliveryDate, atDate)) {
+            LocalDate conception = expectedDeliveryDate.minusWeeks(PREGNANCY_DURATION_IN_WEEKS);
+            customMetrics.put(WEEKS_PREGNANT.getFieldName(), ChronoUnit.WEEKS.between(conception, atDate));
+        }
+        return customMetrics;
+    }
+}

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/reporting/payload/ReportPaymentPropertiesFactory.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/reporting/payload/ReportPaymentPropertiesFactory.java
@@ -1,0 +1,56 @@
+package uk.gov.dhsc.htbhf.claimant.reporting.payload;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import uk.gov.dhsc.htbhf.claimant.entity.PaymentCycle;
+import uk.gov.dhsc.htbhf.claimant.message.context.ReportPaymentMessageContext;
+import uk.gov.dhsc.htbhf.claimant.message.processor.ChildDateOfBirthCalculator;
+import uk.gov.dhsc.htbhf.claimant.message.processor.NextPaymentCycleSummary;
+import uk.gov.dhsc.htbhf.claimant.reporting.ClaimantCategoryCalculator;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static uk.gov.dhsc.htbhf.claimant.reporting.payload.CustomMetric.NUMBER_OF_1ST_OR_FOURTH_BIRTHDAYS_IN_NEXT_CYCLE;
+import static uk.gov.dhsc.htbhf.claimant.reporting.payload.CustomMetric.PAYMENT_FOR_CHILDREN_BETWEEN_ONE_AND_FOUR;
+import static uk.gov.dhsc.htbhf.claimant.reporting.payload.CustomMetric.PAYMENT_FOR_CHILDREN_UNDER_ONE;
+import static uk.gov.dhsc.htbhf.claimant.reporting.payload.CustomMetric.PAYMENT_FOR_PREGNANCY;
+import static uk.gov.dhsc.htbhf.claimant.reporting.payload.EventCategory.PAYMENT;
+
+@Component
+public class ReportPaymentPropertiesFactory extends ReportPropertiesFactory {
+
+    private final ChildDateOfBirthCalculator childDateOfBirthCalculator;
+
+    public ReportPaymentPropertiesFactory(@Value("${google-analytics.tracking-id}") String trackingId,
+                                          ClaimantCategoryCalculator claimantCategoryCalculator,
+                                          ChildDateOfBirthCalculator childDateOfBirthCalculator) {
+        super(trackingId, claimantCategoryCalculator);
+        this.childDateOfBirthCalculator = childDateOfBirthCalculator;
+    }
+
+    public Map<String, String> createReportPropertiesForPaymentEvent(ReportPaymentMessageContext context) {
+        Map<String, String> reportProperties = new LinkedHashMap<>();
+        reportProperties.putAll(mapValuesToString(createMandatoryPropertiesMap()));
+        int totalPaymentAmount = context.getPaymentForPregnancy() + context.getPaymentForChildrenUnderOne() + context.getPaymentForChildrenBetweenOneAndFour();
+        reportProperties.putAll(mapValuesToString(createEventPropertiesMap(context, PAYMENT, totalPaymentAmount)));
+        reportProperties.putAll(mapValuesToString(createCustomDimensionMap(context)));
+        reportProperties.putAll(mapValuesToString(createCustomMetricMapForPaymentEvent(context)));
+        return reportProperties;
+    }
+
+    private Map<String, Object> createCustomMetricMapForPaymentEvent(ReportPaymentMessageContext context) {
+        Map<String, Object> customMetrics = createCommonCustomMetrics(context);
+        addPaymentCycleMetrics(context, customMetrics);
+        return customMetrics;
+    }
+
+    private void addPaymentCycleMetrics(ReportPaymentMessageContext context, Map<String, Object> customMetrics) {
+        PaymentCycle paymentCycle = context.getPaymentCycle();
+        customMetrics.put(PAYMENT_FOR_PREGNANCY.getFieldName(), context.getPaymentForPregnancy());
+        customMetrics.put(PAYMENT_FOR_CHILDREN_UNDER_ONE.getFieldName(), context.getPaymentForChildrenUnderOne());
+        customMetrics.put(PAYMENT_FOR_CHILDREN_BETWEEN_ONE_AND_FOUR.getFieldName(), context.getPaymentForChildrenBetweenOneAndFour());
+        NextPaymentCycleSummary nextPaymentCycleSummary = childDateOfBirthCalculator.getNextPaymentCycleSummary(paymentCycle);
+        customMetrics.put(NUMBER_OF_1ST_OR_FOURTH_BIRTHDAYS_IN_NEXT_CYCLE.getFieldName(), nextPaymentCycleSummary.getNumberOfChildrenTurningOneOrFour());
+    }
+}

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/reporting/MIReporterTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/reporting/MIReporterTest.java
@@ -9,7 +9,8 @@ import uk.gov.dhsc.htbhf.claimant.entity.Claim;
 import uk.gov.dhsc.htbhf.claimant.message.context.ReportClaimMessageContext;
 import uk.gov.dhsc.htbhf.claimant.message.context.ReportPaymentMessageContext;
 import uk.gov.dhsc.htbhf.claimant.model.PostcodeData;
-import uk.gov.dhsc.htbhf.claimant.reporting.payload.ReportPropertiesFactory;
+import uk.gov.dhsc.htbhf.claimant.reporting.payload.ReportClaimPropertiesFactory;
+import uk.gov.dhsc.htbhf.claimant.reporting.payload.ReportPaymentPropertiesFactory;
 import uk.gov.dhsc.htbhf.claimant.repository.ClaimRepository;
 
 import java.util.Map;
@@ -40,7 +41,9 @@ class MIReporterTest {
     @Mock
     private ClaimRepository claimRepository;
     @Mock
-    private ReportPropertiesFactory reportPropertiesFactory;
+    private ReportClaimPropertiesFactory reportClaimPropertiesFactory;
+    @Mock
+    private ReportPaymentPropertiesFactory reportPaymentPropertiesFactory;
     @Mock
     private GoogleAnalyticsClient googleAnalyticsClient;
 
@@ -54,14 +57,14 @@ class MIReporterTest {
         String postcode = claim.getClaimant().getAddress().getPostcode();
         PostcodeData postcodeData = aPostcodeDataObjectForPostcode(postcode);
         given(postcodeDataClient.getPostcodeData(any())).willReturn(postcodeData);
-        given(reportPropertiesFactory.createReportPropertiesForClaimEvent(any())).willReturn(REPORT_PROPERTIES);
+        given(reportClaimPropertiesFactory.createReportPropertiesForClaimEvent(any())).willReturn(REPORT_PROPERTIES);
 
         miReporter.reportClaim(context);
 
         assertThat(claim.getPostcodeData()).isEqualTo(postcodeData);
         verify(postcodeDataClient).getPostcodeData(claim);
         verify(claimRepository).save(claim);
-        verify(reportPropertiesFactory).createReportPropertiesForClaimEvent(context);
+        verify(reportClaimPropertiesFactory).createReportPropertiesForClaimEvent(context);
         verify(googleAnalyticsClient).reportEvent(REPORT_PROPERTIES);
     }
 
@@ -70,12 +73,12 @@ class MIReporterTest {
         PostcodeData postcodeData = aPostcodeDataObjectForPostcode(VALID_POSTCODE);
         Claim claim = aClaimWithPostcodeData(postcodeData);
         ReportClaimMessageContext context = ReportClaimMessageContext.builder().claim(claim).build();
-        given(reportPropertiesFactory.createReportPropertiesForClaimEvent(any())).willReturn(REPORT_PROPERTIES);
+        given(reportClaimPropertiesFactory.createReportPropertiesForClaimEvent(any())).willReturn(REPORT_PROPERTIES);
 
         miReporter.reportClaim(context);
 
         verifyZeroInteractions(postcodeDataClient, claimRepository);
-        verify(reportPropertiesFactory).createReportPropertiesForClaimEvent(context);
+        verify(reportClaimPropertiesFactory).createReportPropertiesForClaimEvent(context);
         verify(googleAnalyticsClient).reportEvent(REPORT_PROPERTIES);
     }
 
@@ -85,13 +88,13 @@ class MIReporterTest {
         PostcodeData postcodeData = aPostcodeDataObjectForPostcode(VALID_POSTCODE);
         ReportPaymentMessageContext context = aReportPaymentMessageContextWithClaim(claim);
         given(postcodeDataClient.getPostcodeData(any())).willReturn(postcodeData);
-        given(reportPropertiesFactory.createReportPropertiesForPaymentEvent(any())).willReturn(REPORT_PROPERTIES);
+        given(reportPaymentPropertiesFactory.createReportPropertiesForPaymentEvent(any())).willReturn(REPORT_PROPERTIES);
 
         miReporter.reportPayment(context);
 
         verify(postcodeDataClient).getPostcodeData(claim);
         verify(claimRepository).save(claim);
-        verify(reportPropertiesFactory).createReportPropertiesForPaymentEvent(context);
+        verify(reportPaymentPropertiesFactory).createReportPropertiesForPaymentEvent(context);
         verify(googleAnalyticsClient).reportEvent(REPORT_PROPERTIES);
     }
 
@@ -100,12 +103,12 @@ class MIReporterTest {
         PostcodeData postcodeData = aPostcodeDataObjectForPostcode(VALID_POSTCODE);
         Claim claim = aClaimWithPostcodeData(postcodeData);
         ReportPaymentMessageContext context = aReportPaymentMessageContextWithClaim(claim);
-        given(reportPropertiesFactory.createReportPropertiesForPaymentEvent(any())).willReturn(REPORT_PROPERTIES);
+        given(reportPaymentPropertiesFactory.createReportPropertiesForPaymentEvent(any())).willReturn(REPORT_PROPERTIES);
 
         miReporter.reportPayment(context);
 
         verifyZeroInteractions(postcodeDataClient, claimRepository);
-        verify(reportPropertiesFactory).createReportPropertiesForPaymentEvent(context);
+        verify(reportPaymentPropertiesFactory).createReportPropertiesForPaymentEvent(context);
         verify(googleAnalyticsClient).reportEvent(REPORT_PROPERTIES);
     }
 }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/reporting/payload/ReportClaimPropertiesFactoryTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/reporting/payload/ReportClaimPropertiesFactoryTest.java
@@ -1,0 +1,158 @@
+package uk.gov.dhsc.htbhf.claimant.reporting.payload;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.dhsc.htbhf.claimant.entity.Claim;
+import uk.gov.dhsc.htbhf.claimant.message.context.ReportClaimMessageContext;
+import uk.gov.dhsc.htbhf.claimant.reporting.ClaimantCategoryCalculator;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Period;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static uk.gov.dhsc.htbhf.claimant.reporting.ClaimAction.NEW;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimTestDataFactory.aClaimWithDueDateAndPostcodeData;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReportClaimPropertiesFactoryTest extends ReportPropertiesFactoryTest {
+
+    @Mock
+    private ClaimantCategoryCalculator claimantCategoryCalculator;
+
+    private ReportClaimPropertiesFactory reportClaimPropertiesFactory;
+
+    @BeforeEach
+    void init() {
+        reportClaimPropertiesFactory = new ReportClaimPropertiesFactory(TRACKING_ID, claimantCategoryCalculator);
+    }
+
+    @Test
+    void shouldCreateReportPropertiesForClaim() {
+        int secondsSinceEvent = 1;
+        LocalDateTime timestamp = LocalDateTime.now().minusSeconds(secondsSinceEvent);
+        List<LocalDate> datesOfBirthOfChildren = singletonList(LocalDate.now().minusMonths(11));
+        ReportClaimMessageContext context = aReportClaimMessageContext(timestamp, datesOfBirthOfChildren, EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS);
+        given(claimantCategoryCalculator.determineClaimantCategory(any(), any(), any())).willReturn(CLAIMANT_CATEGORY);
+
+        Map<String, String> reportProperties = reportClaimPropertiesFactory.createReportPropertiesForClaimEvent(context);
+
+        assertQueueTime(reportProperties, timestamp, secondsSinceEvent);
+        Claim claim = context.getClaim();
+        assertCommonProperties(reportProperties, timestamp, claim, "CLAIM", "NEW");
+        assertThat(reportProperties).contains(
+                entry("ev", "0"), // event value (set to 0 as it's not used for claim events)
+                entry("cm9", getNumberOfWeeksPregnant(claim, timestamp))); // weeks pregnant
+        assertThat(reportProperties).doesNotContainKeys("cm4", "cm5", "cm6", "cm8"); // payment-only custom metrics
+        verify(claimantCategoryCalculator).determineClaimantCategory(claim.getClaimant(), datesOfBirthOfChildren, timestamp.toLocalDate());
+    }
+
+    @Test
+    void shouldImposeMaximumValueForQueueTime() {
+        ReportClaimMessageContext context = aReportClaimMessageContext(LocalDateTime.now().minusHours(5), NO_CHILDREN, NOT_PREGNANT);
+        given(claimantCategoryCalculator.determineClaimantCategory(any(), any(), any())).willReturn(CLAIMANT_CATEGORY);
+
+        Map<String, String> reportProperties = reportClaimPropertiesFactory.createReportPropertiesForClaimEvent(context);
+
+        // queue times longer than 4 hours may cause the event to not be registered:
+        // https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#qt
+        Long queueTime = Long.parseLong(reportProperties.get("qt"));
+        long maxQueueTime = 1000 * 60 * 60 * 4;
+        assertThat(queueTime).isLessThanOrEqualTo(maxQueueTime);
+    }
+
+    @ParameterizedTest(name = "{1} children under 1 and {2} between 1 and 4 given: {0}")
+    @MethodSource("childrensDatesOfBirth")
+    void shouldIncludeMetricsForNumberOfChildren(List<LocalDate> datesOfBirth, long childrenUnderOne, long childrenOneToFour) {
+        ReportClaimMessageContext context = aReportClaimMessageContext(LocalDateTime.now(), datesOfBirth, NOT_PREGNANT);
+        given(claimantCategoryCalculator.determineClaimantCategory(any(), any(), any())).willReturn(CLAIMANT_CATEGORY);
+
+        Map<String, String> reportProperties = reportClaimPropertiesFactory.createReportPropertiesForClaimEvent(context);
+
+        assertThat(reportProperties).contains(
+                entry("cm1", String.valueOf(childrenUnderOne)),
+                entry("cm2", String.valueOf(childrenOneToFour))
+        );
+    }
+
+    static Stream<Arguments> childrensDatesOfBirth() {
+        return Stream.of(
+                Arguments.of(NO_CHILDREN, 0, 0),
+                Arguments.of(null, 0, 0),
+                Arguments.of(TWO_CHILDREN_UNDER_ONE, 2, 0),
+                Arguments.of(ONE_CHILD_UNDER_ONE_AND_ONE_CHILD_BETWEEN_ONE_AND_FOUR, 1, 1),
+                Arguments.of(TWO_CHILDREN_BETWEEN_ONE_AND_FOUR, 0, 2),
+                Arguments.of(ONE_CHILD_FOUR_YEARS_OLD, 0, 0)
+        );
+    }
+
+    @ParameterizedTest(name = "{1} weeks pregnant given {0} since conception")
+    @CsvSource({
+            "P10W, 10",
+            "P20W1D, 20",
+            "P36W6D, 36"
+    })
+    void shouldIncludeMetricsForPregnantClaimant(String timeSinceConception, Long weeksPregnant) {
+        LocalDate expectedDeliveryDate = LocalDate.now().minus(Period.parse(timeSinceConception)).plusWeeks(40);
+        ReportClaimMessageContext context = aReportClaimMessageContext(LocalDateTime.now(), NO_CHILDREN, expectedDeliveryDate);
+        given(claimantCategoryCalculator.determineClaimantCategory(any(), any(), any())).willReturn(CLAIMANT_CATEGORY);
+
+        Map<String, String> reportProperties = reportClaimPropertiesFactory.createReportPropertiesForClaimEvent(context);
+
+        assertThat(reportProperties).contains(
+                entry("cm3", "1"), // PREGNANCIES
+                entry("cm9", String.valueOf(weeksPregnant))
+        );
+    }
+
+    @Test
+    void shouldNotIncludePregnancyWeeksForPregnancyInPast() {
+        LocalDate expectedDeliveryDate = LocalDate.now().minusWeeks(40).plusDays(1);
+        ReportClaimMessageContext context = aReportClaimMessageContext(LocalDateTime.now(), NO_CHILDREN, expectedDeliveryDate);
+        given(claimantCategoryCalculator.determineClaimantCategory(any(), any(), any())).willReturn(CLAIMANT_CATEGORY);
+
+        Map<String, String> reportProperties = reportClaimPropertiesFactory.createReportPropertiesForClaimEvent(context);
+
+        assertThat(reportProperties).contains(entry("cm3", "0"));
+        assertThat(reportProperties).doesNotContainKey("cm9");
+    }
+
+    @Test
+    void shouldNotIncludePregnancyWeeksForClaimantWithoutPregnancy() {
+        ReportClaimMessageContext context = aReportClaimMessageContext(LocalDateTime.now(), NO_CHILDREN, NOT_PREGNANT);
+        given(claimantCategoryCalculator.determineClaimantCategory(any(), any(), any())).willReturn(CLAIMANT_CATEGORY);
+
+        Map<String, String> reportProperties = reportClaimPropertiesFactory.createReportPropertiesForClaimEvent(context);
+
+        assertThat(reportProperties).contains(entry("cm3", "0"));
+        assertThat(reportProperties).doesNotContainKey("cm9");
+    }
+
+    private ReportClaimMessageContext aReportClaimMessageContext(LocalDateTime timestamp,
+                                                                 List<LocalDate> datesOfBirthOfChildren,
+                                                                 LocalDate expectedDeliveryDate) {
+        Claim claim = aClaimWithDueDateAndPostcodeData(expectedDeliveryDate);
+        return ReportClaimMessageContext.builder()
+                .claimAction(NEW)
+                .claim(claim)
+                .datesOfBirthOfChildren(datesOfBirthOfChildren)
+                .timestamp(timestamp)
+                .build();
+    }
+}

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/reporting/payload/ReportPaymentPropertiesFactoryTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/reporting/payload/ReportPaymentPropertiesFactoryTest.java
@@ -1,0 +1,89 @@
+package uk.gov.dhsc.htbhf.claimant.reporting.payload;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.dhsc.htbhf.claimant.entity.Claim;
+import uk.gov.dhsc.htbhf.claimant.message.context.ReportPaymentMessageContext;
+import uk.gov.dhsc.htbhf.claimant.message.processor.ChildDateOfBirthCalculator;
+import uk.gov.dhsc.htbhf.claimant.message.processor.NextPaymentCycleSummary;
+import uk.gov.dhsc.htbhf.claimant.reporting.ClaimantCategoryCalculator;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static uk.gov.dhsc.htbhf.claimant.reporting.PaymentAction.SCHEDULED_PAYMENT;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimTestDataFactory.aClaimWithDueDateAndPostcodeData;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aPaymentCycleWithClaim;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS;
+
+@ExtendWith(MockitoExtension.class)
+class ReportPaymentPropertiesFactoryTest extends ReportPropertiesFactoryTest {
+
+    @Mock
+    private ClaimantCategoryCalculator claimantCategoryCalculator;
+    @Mock
+    private ChildDateOfBirthCalculator childDateOfBirthCalculator;
+
+    private ReportPaymentPropertiesFactory reportClaimPropertiesFactory;
+
+    @BeforeEach
+    void init() {
+        reportClaimPropertiesFactory = new ReportPaymentPropertiesFactory(TRACKING_ID, claimantCategoryCalculator, childDateOfBirthCalculator);
+    }
+
+    @Test
+    void shouldCreateReportPropertiesForPayment() {
+        int secondsSinceEvent = 1;
+        LocalDateTime timestamp = LocalDateTime.now().minusSeconds(secondsSinceEvent);
+        List<LocalDate> datesOfBirthOfChildren = singletonList(LocalDate.now().minusMonths(11));
+        ReportPaymentMessageContext context = aReportPaymentMessageContext(timestamp, datesOfBirthOfChildren, EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS);
+        given(claimantCategoryCalculator.determineClaimantCategory(any(), any(), any())).willReturn(CLAIMANT_CATEGORY);
+        given(childDateOfBirthCalculator.getNextPaymentCycleSummary(context.getPaymentCycle()))
+                .willReturn(NextPaymentCycleSummary.builder()
+                        .numberOfChildrenTurningOne(1)
+                        .numberOfChildrenTurningFour(1)
+                        .build());
+
+        Map<String, String> reportProperties = reportClaimPropertiesFactory.createReportPropertiesForPaymentEvent(context);
+
+        assertQueueTime(reportProperties, timestamp, secondsSinceEvent);
+        Claim claim = context.getClaim();
+        assertCommonProperties(reportProperties, timestamp, claim, "PAYMENT", "SCHEDULED_PAYMENT");
+        assertThat(reportProperties).contains(
+                entry("ev", "300"), // event value is the total payment amount
+                entry("cm4", "100"), // payment for children under one (one child for cycle = 8 vouchers)
+                entry("cm5", "100"), // payment for children between one and four (one child for cycle = 4 vouchers)
+                entry("cm6", "100"), // payment for pregnancy (pregnant for the entire payment cycle = 4 vouchers)
+                entry("cm8", "2") // number of children turning 1 or 4 in the next cycle.
+        );
+        verify(claimantCategoryCalculator).determineClaimantCategory(claim.getClaimant(), datesOfBirthOfChildren, timestamp.toLocalDate());
+        verify(childDateOfBirthCalculator).getNextPaymentCycleSummary(context.getPaymentCycle());
+    }
+
+    private ReportPaymentMessageContext aReportPaymentMessageContext(LocalDateTime timestamp,
+                                                                     List<LocalDate> datesOfBirthOfChildren,
+                                                                     LocalDate expectedDeliveryDate) {
+        Claim claim = aClaimWithDueDateAndPostcodeData(expectedDeliveryDate);
+        return ReportPaymentMessageContext.builder()
+                .paymentAction(SCHEDULED_PAYMENT)
+                .paymentCycle(aPaymentCycleWithClaim(claim))
+                .paymentForPregnancy(100)
+                .paymentForChildrenUnderOne(100)
+                .paymentForChildrenBetweenOneAndFour(100)
+                .claim(claim)
+                .datesOfBirthOfChildren(datesOfBirthOfChildren)
+                .timestamp(timestamp)
+                .build();
+    }
+}

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/reporting/payload/ReportPropertiesFactoryTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/reporting/payload/ReportPropertiesFactoryTest.java
@@ -1,199 +1,35 @@
 package uk.gov.dhsc.htbhf.claimant.reporting.payload;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.dhsc.htbhf.claimant.entity.Claim;
-import uk.gov.dhsc.htbhf.claimant.message.context.ReportClaimMessageContext;
-import uk.gov.dhsc.htbhf.claimant.message.context.ReportPaymentMessageContext;
-import uk.gov.dhsc.htbhf.claimant.message.processor.ChildDateOfBirthCalculator;
-import uk.gov.dhsc.htbhf.claimant.message.processor.NextPaymentCycleSummary;
 import uk.gov.dhsc.htbhf.claimant.model.PostcodeData;
-import uk.gov.dhsc.htbhf.claimant.reporting.ClaimantCategoryCalculator;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Period;
 import java.time.temporal.ChronoUnit;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
 
-import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-import static uk.gov.dhsc.htbhf.claimant.reporting.ClaimAction.NEW;
-import static uk.gov.dhsc.htbhf.claimant.reporting.PaymentAction.SCHEDULED_PAYMENT;
-import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimTestDataFactory.aClaimWithDueDateAndPostcodeData;
-import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aPaymentCycleWithClaim;
-import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.*;
 
-@ExtendWith(MockitoExtension.class)
-class ReportPropertiesFactoryTest {
+abstract class ReportPropertiesFactoryTest {
 
-    private static final String TRACKING_ID = "tracking-id";
-    private static final ClaimantCategory CLAIMANT_CATEGORY = ClaimantCategory.PREGNANT_WITH_CHILDREN;
+    protected static final String TRACKING_ID = "tracking-id";
+    protected static final ClaimantCategory CLAIMANT_CATEGORY = ClaimantCategory.PREGNANT_WITH_CHILDREN;
 
-    @Mock
-    private ClaimantCategoryCalculator claimantCategoryCalculator;
-    @Mock
-    private ChildDateOfBirthCalculator childDateOfBirthCalculator;
-
-    private ReportPropertiesFactory reportPropertiesFactory;
-
-    @BeforeEach
-    void init() {
-        reportPropertiesFactory = new ReportPropertiesFactory(TRACKING_ID, claimantCategoryCalculator, childDateOfBirthCalculator);
-    }
-
-    @Test
-    void shouldCreateReportPropertiesForClaim() {
-        int secondsSinceEvent = 1;
-        LocalDateTime timestamp = LocalDateTime.now().minusSeconds(secondsSinceEvent);
-        List<LocalDate> datesOfBirthOfChildren = singletonList(LocalDate.now().minusMonths(11));
-        ReportClaimMessageContext context = aReportClaimMessageContext(timestamp, datesOfBirthOfChildren, EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS);
-        given(claimantCategoryCalculator.determineClaimantCategory(any(), any(), any())).willReturn(CLAIMANT_CATEGORY);
-
-        Map<String, String> reportProperties = reportPropertiesFactory.createReportPropertiesForClaimEvent(context);
-
-        assertQueueTime(reportProperties, timestamp, secondsSinceEvent);
-        Claim claim = context.getClaim();
-        assertCommonProperties(reportProperties, timestamp, claim, "CLAIM", "NEW");
-        assertThat(reportProperties).contains(
-                entry("ev", "0"), // event value (set to 0 as it's not used for claim events)
-                entry("cm9", getNumberOfWeeksPregnant(claim, timestamp))); // weeks pregnant
-        assertThat(reportProperties).doesNotContainKeys("cm4", "cm5", "cm6", "cm8"); // payment-only custom metrics
-        verify(claimantCategoryCalculator).determineClaimantCategory(claim.getClaimant(), datesOfBirthOfChildren, timestamp.toLocalDate());
-    }
-
-    @Test
-    void shouldCreateReportPropertiesForPayment() {
-        int secondsSinceEvent = 1;
-        LocalDateTime timestamp = LocalDateTime.now().minusSeconds(secondsSinceEvent);
-        List<LocalDate> datesOfBirthOfChildren = singletonList(LocalDate.now().minusMonths(11));
-        ReportPaymentMessageContext context = aReportPaymentMessageContext(timestamp, datesOfBirthOfChildren, EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS);
-        given(claimantCategoryCalculator.determineClaimantCategory(any(), any(), any())).willReturn(CLAIMANT_CATEGORY);
-        given(childDateOfBirthCalculator.getNextPaymentCycleSummary(context.getPaymentCycle()))
-                .willReturn(NextPaymentCycleSummary.builder()
-                        .numberOfChildrenTurningOne(1)
-                        .numberOfChildrenTurningFour(1)
-                        .build());
-
-        Map<String, String> reportProperties = reportPropertiesFactory.createReportPropertiesForPaymentEvent(context);
-
-        assertQueueTime(reportProperties, timestamp, secondsSinceEvent);
-        Claim claim = context.getClaim();
-        assertCommonProperties(reportProperties, timestamp, claim, "PAYMENT", "SCHEDULED_PAYMENT");
-        assertThat(reportProperties).contains(
-                entry("ev", "300"), // event value is the total payment amount
-                entry("cm4", "100"), // payment for children under one (one child for cycle = 8 vouchers)
-                entry("cm5", "100"), // payment for children between one and four (one child for cycle = 4 vouchers)
-                entry("cm6", "100"), // payment for pregnancy (pregnant for the entire payment cycle = 4 vouchers)
-                entry("cm8", "2") // number of children turning 1 or 4 in the next cycle.
-        );
-        verify(claimantCategoryCalculator).determineClaimantCategory(claim.getClaimant(), datesOfBirthOfChildren, timestamp.toLocalDate());
-        verify(childDateOfBirthCalculator).getNextPaymentCycleSummary(context.getPaymentCycle());
-    }
-
-    @Test
-    void shouldImposeMaximumValueForQueueTime() {
-        ReportClaimMessageContext context = aReportClaimMessageContext(LocalDateTime.now().minusHours(5), NO_CHILDREN, NOT_PREGNANT);
-        given(claimantCategoryCalculator.determineClaimantCategory(any(), any(), any())).willReturn(CLAIMANT_CATEGORY);
-
-        Map<String, String> reportProperties = reportPropertiesFactory.createReportPropertiesForClaimEvent(context);
-
-        // queue times longer than 4 hours may cause the event to not be registered:
-        // https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#qt
-        Long queueTime = Long.parseLong(reportProperties.get("qt"));
-        long maxQueueTime = 1000 * 60 * 60 * 4;
-        assertThat(queueTime).isLessThanOrEqualTo(maxQueueTime);
-    }
-
-    @ParameterizedTest(name = "{1} children under 1 and {2} between 1 and 4 given: {0}")
-    @MethodSource("childrensDatesOfBirth")
-    void shouldIncludeMetricsForNumberOfChildren(List<LocalDate> datesOfBirth, long childrenUnderOne, long childrenOneToFour) {
-        ReportClaimMessageContext context = aReportClaimMessageContext(LocalDateTime.now(), datesOfBirth, NOT_PREGNANT);
-        given(claimantCategoryCalculator.determineClaimantCategory(any(), any(), any())).willReturn(CLAIMANT_CATEGORY);
-
-        Map<String, String> reportProperties = reportPropertiesFactory.createReportPropertiesForClaimEvent(context);
-
-        assertThat(reportProperties).contains(
-                entry("cm1", String.valueOf(childrenUnderOne)),
-                entry("cm2", String.valueOf(childrenOneToFour))
-        );
-    }
-
-    static Stream<Arguments> childrensDatesOfBirth() {
-        return Stream.of(
-                Arguments.of(NO_CHILDREN, 0, 0),
-                Arguments.of(null, 0, 0),
-                Arguments.of(TWO_CHILDREN_UNDER_ONE, 2, 0),
-                Arguments.of(ONE_CHILD_UNDER_ONE_AND_ONE_CHILD_BETWEEN_ONE_AND_FOUR, 1, 1),
-                Arguments.of(TWO_CHILDREN_BETWEEN_ONE_AND_FOUR, 0, 2),
-                Arguments.of(ONE_CHILD_FOUR_YEARS_OLD, 0, 0)
-        );
-    }
-
-    @ParameterizedTest(name = "{1} weeks pregnant given {0} since conception")
-    @CsvSource({
-            "P10W, 10",
-            "P20W1D, 20",
-            "P36W6D, 36"
-    })
-    void shouldIncludeMetricsForPregnantClaimant(String timeSinceConception, Long weeksPregnant) {
-        LocalDate expectedDeliveryDate = LocalDate.now().minus(Period.parse(timeSinceConception)).plusWeeks(40);
-        ReportClaimMessageContext context = aReportClaimMessageContext(LocalDateTime.now(), NO_CHILDREN, expectedDeliveryDate);
-        given(claimantCategoryCalculator.determineClaimantCategory(any(), any(), any())).willReturn(CLAIMANT_CATEGORY);
-
-        Map<String, String> reportProperties = reportPropertiesFactory.createReportPropertiesForClaimEvent(context);
-
-        assertThat(reportProperties).contains(
-                entry("cm3", "1"), // PREGNANCIES
-                entry("cm9", String.valueOf(weeksPregnant))
-        );
-    }
-
-    @Test
-    void shouldNotIncludePregnancyWeeksForPregnancyInPast() {
-        LocalDate expectedDeliveryDate = LocalDate.now().minusWeeks(40).plusDays(1);
-        ReportClaimMessageContext context = aReportClaimMessageContext(LocalDateTime.now(), NO_CHILDREN, expectedDeliveryDate);
-        given(claimantCategoryCalculator.determineClaimantCategory(any(), any(), any())).willReturn(CLAIMANT_CATEGORY);
-
-        Map<String, String> reportProperties = reportPropertiesFactory.createReportPropertiesForClaimEvent(context);
-
-        assertThat(reportProperties).contains(entry("cm3", "0"));
-        assertThat(reportProperties).doesNotContainKey("cm9");
-    }
-
-    @Test
-    void shouldNotIncludePregnancyWeeksForClaimantWithoutPregnancy() {
-        ReportClaimMessageContext context = aReportClaimMessageContext(LocalDateTime.now(), NO_CHILDREN, NOT_PREGNANT);
-        given(claimantCategoryCalculator.determineClaimantCategory(any(), any(), any())).willReturn(CLAIMANT_CATEGORY);
-
-        Map<String, String> reportProperties = reportPropertiesFactory.createReportPropertiesForClaimEvent(context);
-
-        assertThat(reportProperties).contains(entry("cm3", "0"));
-        assertThat(reportProperties).doesNotContainKey("cm9");
-    }
-
-    private void assertQueueTime(Map<String, String> reportProperties, LocalDateTime timestamp, int secondsSinceEvent) {
+    protected void assertQueueTime(Map<String, String> reportProperties, LocalDateTime timestamp, int secondsSinceEvent) {
         // Queue time is number of milliseconds since now and the timestamp value. Therefore a timestamp one second ago should have a queue time >= 1000
         Long queueTime = Long.parseLong(reportProperties.get("qt"));
         Long maxPossibleQueueTime = ChronoUnit.MILLIS.between(timestamp, LocalDateTime.now());
         assertThat(queueTime).isBetween(TimeUnit.SECONDS.toMillis(secondsSinceEvent), maxPossibleQueueTime);
     }
 
-    private void assertCommonProperties(Map<String, String> reportProperties, LocalDateTime timestamp, Claim claim, String eventCategory, String eventAction) {
+    protected void assertCommonProperties(Map<String, String> reportProperties,
+                                          LocalDateTime timestamp,
+                                          Claim claim,
+                                          String eventCategory,
+                                          String eventAction) {
         PostcodeData postcodeData = claim.getPostcodeData();
         assertThat(reportProperties).contains(
                 entry("t", "event"),
@@ -218,40 +54,12 @@ class ReportPropertiesFactoryTest {
         );
     }
 
-    private ReportClaimMessageContext aReportClaimMessageContext(LocalDateTime timestamp,
-                                                                 List<LocalDate> datesOfBirthOfChildren,
-                                                                 LocalDate expectedDeliveryDate) {
-        Claim claim = aClaimWithDueDateAndPostcodeData(expectedDeliveryDate);
-        return ReportClaimMessageContext.builder()
-                .claimAction(NEW)
-                .claim(claim)
-                .datesOfBirthOfChildren(datesOfBirthOfChildren)
-                .timestamp(timestamp)
-                .build();
-    }
-
-    private ReportPaymentMessageContext aReportPaymentMessageContext(LocalDateTime timestamp,
-                                                                     List<LocalDate> datesOfBirthOfChildren,
-                                                                     LocalDate expectedDeliveryDate) {
-        Claim claim = aClaimWithDueDateAndPostcodeData(expectedDeliveryDate);
-        return ReportPaymentMessageContext.builder()
-                .paymentAction(SCHEDULED_PAYMENT)
-                .paymentCycle(aPaymentCycleWithClaim(claim))
-                .paymentForPregnancy(100)
-                .paymentForChildrenUnderOne(100)
-                .paymentForChildrenBetweenOneAndFour(100)
-                .claim(claim)
-                .datesOfBirthOfChildren(datesOfBirthOfChildren)
-                .timestamp(timestamp)
-                .build();
-    }
-
-    private String getNumberOfWeeksPregnant(Claim claim, LocalDateTime timestamp) {
+    protected String getNumberOfWeeksPregnant(Claim claim, LocalDateTime timestamp) {
         LocalDate conception = claim.getClaimant().getExpectedDeliveryDate().minusWeeks(40);
         return String.valueOf(ChronoUnit.WEEKS.between(conception, timestamp));
     }
 
-    private String getExpectedClaimantAge(Claim claim, LocalDateTime timestamp) {
+    protected String getExpectedClaimantAge(Claim claim, LocalDateTime timestamp) {
         long claimantAge = Period.between(claim.getClaimant().getDateOfBirth(), timestamp.toLocalDate()).getYears();
         return String.valueOf(claimantAge);
     }


### PR DESCRIPTION
- Split report properties into two separate classes, one for claims, one for payments.
- This will be necessary for a future PR which will add additional logic for claim events only.