### PR TITLE
NO-JIRA upgraded spring boot to 2.2.0, added an ObjectMapper bean

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 }
 
 plugins {
-    id "org.springframework.boot" version "2.1.9.RELEASE"
+    id "org.springframework.boot" version "2.2.0.RELEASE"
     id 'io.franzbecker.gradle-lombok' version '1.14'
     id "org.owasp.dependencycheck" version "4.0.0.1"
     id "com.github.spotbugs" version "2.0.0"

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/ClaimantServiceApplicationTests.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/ClaimantServiceApplicationTests.java
@@ -1,5 +1,7 @@
 package uk.gov.dhsc.htbhf.claimant;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -8,9 +10,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.dhsc.htbhf.claimant.model.ClaimantDTO;
 import uk.gov.dhsc.htbhf.swagger.SwaggerGenerationUtil;
 
 import java.io.IOException;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = ClaimantServiceApplication.class,
@@ -24,6 +30,9 @@ public class ClaimantServiceApplicationTests {
     @Autowired
     private TestRestTemplate testRestTemplate;
 
+    @Autowired
+    private ObjectMapper objectMapper;
+
     @Test
     public void contextLoads() {
     }
@@ -33,4 +42,12 @@ public class ClaimantServiceApplicationTests {
         SwaggerGenerationUtil.assertSwaggerDocumentationRetrieved(testRestTemplate, port);
     }
 
+    @Test
+    public void datesAreSerialisedCorrectly() throws JsonProcessingException {
+        ClaimantDTO dto = ClaimantDTO.builder().dateOfBirth(LocalDate.of(1970, 1, 31)).build();
+
+        String output = objectMapper.writeValueAsString(dto);
+
+        assertThat(output).contains("1970-01-31");
+    }
 }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/PayloadMapperTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/PayloadMapperTest.java
@@ -1,5 +1,6 @@
 package uk.gov.dhsc.htbhf.claimant.message;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,7 +35,7 @@ class PayloadMapperTest {
     void shouldThrownExceptionWhenMappingFails() throws IOException {
         //Given
         Message message = aValidMessage();
-        IOException testException = new IOException("Error reading value");
+        JsonMappingException testException = new JsonMappingException(() -> { }, "Error reading value");
         given(objectMapper.readValue(anyString(), eq(NewCardRequestMessagePayload.class))).willThrow(testException);
 
         //When

--- a/smoke_tests/build.gradle
+++ b/smoke_tests/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '2.1.9.RELEASE'
+        springBootVersion = '2.2.0.RELEASE'
         junitVersion = '5.3.2'
     }
 }


### PR DESCRIPTION
Just upgrading Spring without adding an ObjectMapper caused the serialisation of dates to go wrong. I'm happier explicitly defining how they should be serialised anyway. The new version of Jackson also changed the exceptions thrown by ObjectMapper.