### PR TITLE
HTBHF-2377 Refactored DetermineEntitlementMessageProcessor ineligible…

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/entitlement/IneligibleEntitlementDecisionHandler.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/entitlement/IneligibleEntitlementDecisionHandler.java
@@ -1,0 +1,105 @@
+package uk.gov.dhsc.htbhf.claimant.entitlement;
+
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+import uk.gov.dhsc.htbhf.claimant.communications.DetermineEntitlementNotificationHandler;
+import uk.gov.dhsc.htbhf.claimant.entity.Claim;
+import uk.gov.dhsc.htbhf.claimant.entity.PaymentCycle;
+import uk.gov.dhsc.htbhf.claimant.message.processor.ChildDateOfBirthCalculator;
+import uk.gov.dhsc.htbhf.claimant.model.ClaimStatus;
+import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityAndEntitlementDecision;
+import uk.gov.dhsc.htbhf.claimant.repository.ClaimRepository;
+import uk.gov.dhsc.htbhf.claimant.service.ClaimMessageSender;
+import uk.gov.dhsc.htbhf.claimant.service.audit.EventAuditor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static uk.gov.dhsc.htbhf.claimant.entity.CardStatus.PENDING_CANCELLATION;
+import static uk.gov.dhsc.htbhf.claimant.reporting.ClaimAction.UPDATED_FROM_ACTIVE_TO_EXPIRED;
+import static uk.gov.dhsc.htbhf.claimant.reporting.ClaimAction.UPDATED_FROM_ACTIVE_TO_PENDING_EXPIRY;
+
+@Component
+@AllArgsConstructor
+public class IneligibleEntitlementDecisionHandler {
+
+    private ClaimRepository claimRepository;
+    private DetermineEntitlementNotificationHandler determineEntitlementNotificationHandler;
+    private PregnancyEntitlementCalculator pregnancyEntitlementCalculator;
+    private ChildDateOfBirthCalculator childDateOfBirthCalculator;
+    private EventAuditor eventAuditor;
+    private ClaimMessageSender claimMessageSender;
+
+    /**
+     * Handles the processing of ineligible {@link EligibilityAndEntitlementDecision}.
+     * This includes updating claim/card statuses and sending notifications if necessary.
+     *
+     * @param claim the claim the decision relates to
+     * @param previousPaymentCycle the claim's previous payment cycle
+     * @param currentPaymentCycle the claim's current payment cycle
+     * @param decision the ineligible entitlement decision
+     */
+    public void handleIneligibleDecision(Claim claim,
+                                         PaymentCycle previousPaymentCycle,
+                                         PaymentCycle currentPaymentCycle,
+                                         EligibilityAndEntitlementDecision decision) {
+
+        if (shouldExpireClaim(decision, previousPaymentCycle, currentPaymentCycle)) {
+            expireActiveClaim(claim, decision.getDateOfBirthOfChildren());
+        } else if (decision.getQualifyingBenefitEligibilityStatus().isNotEligible()) {
+            handleLossOfQualifyingBenefitStatus(claim, decision.getDateOfBirthOfChildren());
+        } else {
+            handleNoLongerEligibleForSchemeAsNoChildrenAndNotPregnant(claim, decision.getDateOfBirthOfChildren());
+        }
+
+        setCardStatusToPendingCancellation(claim);
+    }
+
+    private boolean shouldExpireClaim(EligibilityAndEntitlementDecision decision, PaymentCycle previousPaymentCycle, PaymentCycle currentPaymentCycle) {
+        if (decision.childrenPresent() || claimantIsPregnantInCycle(currentPaymentCycle)) {
+            return false;
+        }
+        if (childrenExistedInPreviousCycleAndNowOver4(previousPaymentCycle, currentPaymentCycle)) {
+            return true;
+        }
+        return claimantIsPregnantInCycle(previousPaymentCycle);
+    }
+
+    private boolean childrenExistedInPreviousCycleAndNowOver4(PaymentCycle previousPaymentCycle, PaymentCycle currentPaymentCycle) {
+        return childDateOfBirthCalculator.hadChildrenUnder4AtStartOfPaymentCycle(previousPaymentCycle)
+                && !childDateOfBirthCalculator.hadChildrenUnderFourAtGivenDate(previousPaymentCycle.getChildrenDob(), currentPaymentCycle.getCycleStartDate());
+    }
+
+    //Use the PregnancyEntitlementCalculator to check that the claimant is either not pregnant or their pregnancy date is
+    //considered too far in the past.
+    private boolean claimantIsPregnantInCycle(PaymentCycle paymentCycle) {
+        return pregnancyEntitlementCalculator.isEntitledToVoucher(paymentCycle.getExpectedDeliveryDate(), paymentCycle.getCycleStartDate());
+    }
+
+    private void handleLossOfQualifyingBenefitStatus(Claim claim, List<LocalDate> dateOfBirthOfChildren) {
+        updateClaimStatus(claim, ClaimStatus.PENDING_EXPIRY);
+        determineEntitlementNotificationHandler.sendClaimNoLongerEligibleEmail(claim);
+        claimMessageSender.sendReportClaimMessage(claim, dateOfBirthOfChildren, UPDATED_FROM_ACTIVE_TO_PENDING_EXPIRY);
+    }
+
+    private void handleNoLongerEligibleForSchemeAsNoChildrenAndNotPregnant(Claim claim, List<LocalDate> dateOfBirthOfChildren) {
+        expireActiveClaim(claim, dateOfBirthOfChildren);
+        determineEntitlementNotificationHandler.sendNoChildrenOnFeedClaimNoLongerEligibleEmail(claim);
+    }
+
+    private void expireActiveClaim(Claim claim, List<LocalDate> dateOfBirthOfChildren) {
+        updateClaimStatus(claim, ClaimStatus.EXPIRED);
+        eventAuditor.auditExpiredClaim(claim);
+        claimMessageSender.sendReportClaimMessage(claim, dateOfBirthOfChildren, UPDATED_FROM_ACTIVE_TO_EXPIRED);
+    }
+
+    private void setCardStatusToPendingCancellation(Claim claim) {
+        claim.updateCardStatus(PENDING_CANCELLATION);
+        claimRepository.save(claim);
+    }
+
+    private void updateClaimStatus(Claim claim, ClaimStatus claimStatus) {
+        claim.updateClaimStatus(claimStatus);
+        claimRepository.save(claim);
+    }
+}

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/processor/DetermineEntitlementMessageProcessor.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/processor/DetermineEntitlementMessageProcessor.java
@@ -3,8 +3,7 @@ package uk.gov.dhsc.htbhf.claimant.message.processor;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import uk.gov.dhsc.htbhf.claimant.communications.DetermineEntitlementNotificationHandler;
-import uk.gov.dhsc.htbhf.claimant.entitlement.PregnancyEntitlementCalculator;
+import uk.gov.dhsc.htbhf.claimant.entitlement.IneligibleEntitlementDecisionHandler;
 import uk.gov.dhsc.htbhf.claimant.entity.Claim;
 import uk.gov.dhsc.htbhf.claimant.entity.Message;
 import uk.gov.dhsc.htbhf.claimant.entity.PaymentCycle;
@@ -12,30 +11,20 @@ import uk.gov.dhsc.htbhf.claimant.message.*;
 import uk.gov.dhsc.htbhf.claimant.message.context.DetermineEntitlementMessageContext;
 import uk.gov.dhsc.htbhf.claimant.message.context.MessageContextLoader;
 import uk.gov.dhsc.htbhf.claimant.message.payload.MessagePayload;
-import uk.gov.dhsc.htbhf.claimant.model.ClaimStatus;
 import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityAndEntitlementDecision;
-import uk.gov.dhsc.htbhf.claimant.repository.ClaimRepository;
-import uk.gov.dhsc.htbhf.claimant.service.ClaimMessageSender;
 import uk.gov.dhsc.htbhf.claimant.service.EligibilityAndEntitlementService;
-import uk.gov.dhsc.htbhf.claimant.service.audit.EventAuditor;
 import uk.gov.dhsc.htbhf.claimant.service.payments.PaymentCycleService;
 
-import java.time.LocalDate;
-import java.util.List;
 import javax.transaction.Transactional;
 
-import static uk.gov.dhsc.htbhf.claimant.entity.CardStatus.PENDING_CANCELLATION;
 import static uk.gov.dhsc.htbhf.claimant.message.MessageStatus.COMPLETED;
 import static uk.gov.dhsc.htbhf.claimant.message.MessageType.DETERMINE_ENTITLEMENT;
 import static uk.gov.dhsc.htbhf.claimant.model.ClaimStatus.ACTIVE;
-import static uk.gov.dhsc.htbhf.claimant.reporting.ClaimAction.UPDATED_FROM_ACTIVE_TO_EXPIRED;
-import static uk.gov.dhsc.htbhf.claimant.reporting.ClaimAction.UPDATED_FROM_ACTIVE_TO_PENDING_EXPIRY;
 import static uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus.ELIGIBLE;
 
 @Slf4j
 @Component
 @AllArgsConstructor
-@SuppressWarnings("PMD.TooManyMethods")
 public class DetermineEntitlementMessageProcessor implements MessageTypeProcessor {
 
     private EligibilityAndEntitlementService eligibilityAndEntitlementService;
@@ -44,19 +33,9 @@ public class DetermineEntitlementMessageProcessor implements MessageTypeProcesso
 
     private PaymentCycleService paymentCycleService;
 
-    private ClaimRepository claimRepository;
-
     private MessageQueueClient messageQueueClient;
 
-    private DetermineEntitlementNotificationHandler determineEntitlementNotificationHandler;
-
-    private PregnancyEntitlementCalculator pregnancyEntitlementCalculator;
-
-    private ChildDateOfBirthCalculator childDateOfBirthCalculator;
-
-    private EventAuditor eventAuditor;
-
-    private ClaimMessageSender claimMessageSender;
+    private IneligibleEntitlementDecisionHandler ineligibleEntitlementDecisionHandler;
 
     @Override
     public MessageType supportsMessageType() {
@@ -92,72 +71,13 @@ public class DetermineEntitlementMessageProcessor implements MessageTypeProcesso
         if (decision.getEligibilityStatus() == ELIGIBLE) {
             createMakePaymentMessage(currentPaymentCycle);
         } else if (claim.getClaimStatus() == ACTIVE) {
-            if (shouldExpireClaim(decision, previousPaymentCycle, currentPaymentCycle)) {
-                expireActiveClaim(claim, decision.getDateOfBirthOfChildren());
-            } else if (decision.getQualifyingBenefitEligibilityStatus().isNotEligible()) {
-                handleLossOfQualifyingBenefitStatus(claim, decision.getDateOfBirthOfChildren());
-            } else {
-                handleNoLongerEligibleForSchemeAsNoChildrenAndNotPregnant(claim, decision.getDateOfBirthOfChildren());
-            }
-
-            setCardStatusToPendingCancellation(claim);
+            ineligibleEntitlementDecisionHandler.handleIneligibleDecision(claim, previousPaymentCycle, currentPaymentCycle, decision);
         }
         //TODO HTBHF-1296: If not ACTIVE, PENDING_EXPIRY will be moved to EXPIRED after 16 weeks.
-    }
-
-    private boolean shouldExpireClaim(EligibilityAndEntitlementDecision decision, PaymentCycle previousPaymentCycle, PaymentCycle currentPaymentCycle) {
-        if (decision.childrenPresent() || claimantIsPregnantInCycle(currentPaymentCycle)) {
-            return false;
-        }
-        if (childrenExistedInPreviousCycleAndNowOver4(previousPaymentCycle, currentPaymentCycle)) {
-            return true;
-        }
-        return claimantIsPregnantInCycle(previousPaymentCycle);
-    }
-
-    private boolean childrenExistedInPreviousCycleAndNowOver4(PaymentCycle previousPaymentCycle, PaymentCycle currentPaymentCycle) {
-        return childDateOfBirthCalculator.hadChildrenUnder4AtStartOfPaymentCycle(previousPaymentCycle)
-                && !childDateOfBirthCalculator.hadChildrenUnderFourAtGivenDate(previousPaymentCycle.getChildrenDob(), currentPaymentCycle.getCycleStartDate());
-    }
-
-    //Use the PregnancyEntitlementCalculator to check that the claimant is either not pregnant or their pregnancy date is
-    //considered too far in the past.
-    private boolean claimantIsPregnantInCycle(PaymentCycle paymentCycle) {
-        return pregnancyEntitlementCalculator.isEntitledToVoucher(
-                paymentCycle.getExpectedDeliveryDate(),
-                paymentCycle.getCycleStartDate());
     }
 
     private void createMakePaymentMessage(PaymentCycle paymentCycle) {
         MessagePayload messagePayload = MessagePayloadFactory.buildMakePaymentMessagePayload(paymentCycle);
         messageQueueClient.sendMessage(messagePayload, MessageType.MAKE_PAYMENT);
     }
-
-    private void handleLossOfQualifyingBenefitStatus(Claim claim, List<LocalDate> dateOfBirthOfChildren) {
-        updateClaimStatus(claim, ClaimStatus.PENDING_EXPIRY);
-        determineEntitlementNotificationHandler.sendClaimNoLongerEligibleEmail(claim);
-        claimMessageSender.sendReportClaimMessage(claim, dateOfBirthOfChildren, UPDATED_FROM_ACTIVE_TO_PENDING_EXPIRY);
-    }
-
-    private void handleNoLongerEligibleForSchemeAsNoChildrenAndNotPregnant(Claim claim, List<LocalDate> dateOfBirthOfChildren) {
-        expireActiveClaim(claim, dateOfBirthOfChildren);
-        determineEntitlementNotificationHandler.sendNoChildrenOnFeedClaimNoLongerEligibleEmail(claim);
-    }
-
-    private void expireActiveClaim(Claim claim, List<LocalDate> dateOfBirthOfChildren) {
-        updateClaimStatus(claim, ClaimStatus.EXPIRED);
-        eventAuditor.auditExpiredClaim(claim);
-        claimMessageSender.sendReportClaimMessage(claim, dateOfBirthOfChildren, UPDATED_FROM_ACTIVE_TO_EXPIRED);
-    }
-
-    private void setCardStatusToPendingCancellation(Claim claim) {
-        claim.updateCardStatus(PENDING_CANCELLATION);
-        claimRepository.save(claim);
-    }
-
-    private void updateClaimStatus(Claim claim, ClaimStatus claimStatus) {
-        claim.updateClaimStatus(claimStatus);
-        claimRepository.save(claim);
-    }
-
 }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/entitlement/IneligibleEntitlementDecisionHandlerTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/entitlement/IneligibleEntitlementDecisionHandlerTest.java
@@ -1,0 +1,263 @@
+package uk.gov.dhsc.htbhf.claimant.entitlement;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.dhsc.htbhf.claimant.communications.DetermineEntitlementNotificationHandler;
+import uk.gov.dhsc.htbhf.claimant.entity.CardStatus;
+import uk.gov.dhsc.htbhf.claimant.entity.Claim;
+import uk.gov.dhsc.htbhf.claimant.entity.PaymentCycle;
+import uk.gov.dhsc.htbhf.claimant.message.processor.ChildDateOfBirthCalculator;
+import uk.gov.dhsc.htbhf.claimant.model.ClaimStatus;
+import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityAndEntitlementDecision;
+import uk.gov.dhsc.htbhf.claimant.model.eligibility.QualifyingBenefitEligibilityStatus;
+import uk.gov.dhsc.htbhf.claimant.repository.ClaimRepository;
+import uk.gov.dhsc.htbhf.claimant.service.ClaimMessageSender;
+import uk.gov.dhsc.htbhf.claimant.service.audit.EventAuditor;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+import static uk.gov.dhsc.htbhf.claimant.entity.CardStatus.PENDING_CANCELLATION;
+import static uk.gov.dhsc.htbhf.claimant.model.eligibility.QualifyingBenefitEligibilityStatus.CONFIRMED;
+import static uk.gov.dhsc.htbhf.claimant.model.eligibility.QualifyingBenefitEligibilityStatus.NOT_CONFIRMED;
+import static uk.gov.dhsc.htbhf.claimant.reporting.ClaimAction.UPDATED_FROM_ACTIVE_TO_EXPIRED;
+import static uk.gov.dhsc.htbhf.claimant.reporting.ClaimAction.UPDATED_FROM_ACTIVE_TO_PENDING_EXPIRY;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimTestDataFactory.aClaimWithExpectedDeliveryDateAndChildrenDobs;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.EligibilityAndEntitlementTestDataFactory.aDecisionWithStatusAndChildren;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aPaymentCycleWithClaim;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aPaymentCycleWithStartDateAndClaim;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.*;
+import static uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus.INELIGIBLE;
+
+@ExtendWith(MockitoExtension.class)
+class IneligibleEntitlementDecisionHandlerTest {
+
+    @Mock
+    private ClaimRepository claimRepository;
+    @Mock
+    private DetermineEntitlementNotificationHandler determineEntitlementNotificationHandler;
+    @Mock
+    private PregnancyEntitlementCalculator pregnancyEntitlementCalculator;
+    @Mock
+    private ChildDateOfBirthCalculator childDateOfBirthCalculator;
+    @Mock
+    private EventAuditor eventAuditor;
+    @Mock
+    private ClaimMessageSender claimMessageSender;
+
+    @InjectMocks
+    private IneligibleEntitlementDecisionHandler handler;
+
+    //Test for HTBHF-2182 has the following context:
+    // Previous cycle: children exist and are under 4 but will be 4 in the next cycle, not pregnant
+    // Current cycle: no children and not pregnant
+    @ParameterizedTest(name = "Qualifying benefit status={0}")
+    @ValueSource(strings = {"CONFIRMED", "NOT_CONFIRMED"})
+    void shouldExpireClaimWhenIneligibleWithNoChildrenAndNotPregnant(QualifyingBenefitEligibilityStatus qualifyingBenefitEligibilityStatus) {
+        //Given
+        //Claimant has children under 4 at the previous payment cycle that would still over 4 now (but not reported by DWP).
+        given(childDateOfBirthCalculator.hadChildrenUnder4AtStartOfPaymentCycle(any())).willReturn(true);
+        given(childDateOfBirthCalculator.hadChildrenUnderFourAtGivenDate(any(), any())).willReturn(false);
+
+        List<LocalDate> currentCycleChildrenDobs = NO_CHILDREN;
+        EligibilityAndEntitlementDecision decision = aDecisionWithStatusAndChildren(INELIGIBLE, qualifyingBenefitEligibilityStatus, currentCycleChildrenDobs);
+        given(pregnancyEntitlementCalculator.isEntitledToVoucher(any(), any())).willReturn(false);
+
+        Claim claimAtPreviousCycle = aClaimWithExpectedDeliveryDateAndChildrenDobs(NOT_PREGNANT, SINGLE_NEARLY_FOUR_YEAR_OLD);
+        Claim claimAtCurrentCycle = aClaimWithExpectedDeliveryDateAndChildrenDobs(NOT_PREGNANT, currentCycleChildrenDobs);
+        PaymentCycle currentPaymentCycle = aPaymentCycleWithClaim(claimAtCurrentCycle);
+        LocalDate previousCycleStartDate = LocalDate.now().minusWeeks(4);
+        PaymentCycle previousPaymentCycle = aPaymentCycleWithStartDateAndClaim(previousCycleStartDate, claimAtPreviousCycle);
+
+        //When
+        handler.handleIneligibleDecision(claimAtCurrentCycle, previousPaymentCycle, currentPaymentCycle, decision);
+
+        //Then
+        verifyClaimSavedWithStatus(ClaimStatus.EXPIRED, PENDING_CANCELLATION);
+        LocalDate currentPaymentCycleStartDate = currentPaymentCycle.getCycleStartDate();
+        verify(pregnancyEntitlementCalculator).isEntitledToVoucher(NOT_PREGNANT, currentPaymentCycleStartDate);
+        verify(childDateOfBirthCalculator).hadChildrenUnder4AtStartOfPaymentCycle(previousPaymentCycle);
+        verify(childDateOfBirthCalculator).hadChildrenUnderFourAtGivenDate(SINGLE_NEARLY_FOUR_YEAR_OLD, currentPaymentCycleStartDate);
+        verify(eventAuditor).auditExpiredClaim(claimAtCurrentCycle);
+        verify(claimMessageSender).sendReportClaimMessage(claimAtCurrentCycle, currentCycleChildrenDobs, UPDATED_FROM_ACTIVE_TO_EXPIRED);
+        verifyNoMoreInteractions(determineEntitlementNotificationHandler);
+    }
+
+    //Test for HTBHF-2185 has the following context:
+    // Previous cycle: children exist and are under 4, not pregnant or pregnant (parameterised)
+    // Current cycle: no children and not pregnant
+    @ParameterizedTest(name = "Expected delivery date previous cycle={0}")
+    @MethodSource("provideArgumentsForPreviousCycleExpectedDeliveryDate")
+    void shouldExpireClaimWhenChildDisappearsFromFeedAndNotPregnant(LocalDate previousCycleExpectedDeliveryDate) {
+        //Given
+        //Claimant has children under 4 at the previous payment cycle that would still be under 4 now (but not reported by DWP).
+        given(childDateOfBirthCalculator.hadChildrenUnder4AtStartOfPaymentCycle(any())).willReturn(true);
+        given(childDateOfBirthCalculator.hadChildrenUnderFourAtGivenDate(any(), any())).willReturn(true);
+
+        List<LocalDate> currentCycleChildrenDobs = NO_CHILDREN;
+        Claim claimAtPreviousCycle = aClaimWithExpectedDeliveryDateAndChildrenDobs(previousCycleExpectedDeliveryDate, SINGLE_THREE_YEAR_OLD);
+        Claim claimAtCurrentCycle = aClaimWithExpectedDeliveryDateAndChildrenDobs(NOT_PREGNANT, currentCycleChildrenDobs);
+        PaymentCycle currentPaymentCycle = aPaymentCycleWithClaim(claimAtCurrentCycle);
+        LocalDate previousCycleStartDate = LocalDate.now().minusWeeks(4);
+        PaymentCycle previousPaymentCycle = aPaymentCycleWithStartDateAndClaim(previousCycleStartDate, claimAtPreviousCycle);
+
+        EligibilityAndEntitlementDecision decision = aDecisionWithStatusAndChildren(INELIGIBLE, CONFIRMED, currentCycleChildrenDobs);
+        given(pregnancyEntitlementCalculator.isEntitledToVoucher(any(), any())).willReturn(false);
+
+        //When
+        handler.handleIneligibleDecision(claimAtCurrentCycle, previousPaymentCycle, currentPaymentCycle, decision);
+
+        //Then
+        verifyClaimSavedWithStatus(ClaimStatus.EXPIRED, PENDING_CANCELLATION);
+        verify(determineEntitlementNotificationHandler).sendNoChildrenOnFeedClaimNoLongerEligibleEmail(claimAtCurrentCycle);
+        LocalDate currentPaymentCycleStartDate = currentPaymentCycle.getCycleStartDate();
+        verify(pregnancyEntitlementCalculator).isEntitledToVoucher(NOT_PREGNANT, currentPaymentCycleStartDate);
+        verify(childDateOfBirthCalculator).hadChildrenUnder4AtStartOfPaymentCycle(previousPaymentCycle);
+        verify(childDateOfBirthCalculator).hadChildrenUnderFourAtGivenDate(SINGLE_THREE_YEAR_OLD, currentPaymentCycleStartDate);
+        verify(eventAuditor).auditExpiredClaim(claimAtCurrentCycle);
+        verify(claimMessageSender).sendReportClaimMessage(claimAtCurrentCycle, currentCycleChildrenDobs, UPDATED_FROM_ACTIVE_TO_EXPIRED);
+    }
+
+    //HTBHF-1757 Children in current cycle, DWP returns ineligible, varying on pregnancy and children in previous cycle
+    @ParameterizedTest(name = "Children DOB previous cycle={0}, expected delivery date previous cycle={1}, expected delivery date current cycle={2}")
+    @MethodSource("provideArgumentsForPendingExpiryTestsWithChildrenInCurrentCycle")
+    void shouldUpdateClaimToPendingExpiryWhenClaimantIsNotEligibleWithChildrenInCurrentCycle(
+            List<LocalDate> previousCycleChildrenDobs,
+            LocalDate previousCycleExpectedDeliveryDate,
+            LocalDate currentCycleExpectedDeliveryDate) {
+
+        //Had children in last cycle who are under 4 at the start of the current payment cycle.
+        given(childDateOfBirthCalculator.hadChildrenUnder4AtStartOfPaymentCycle(any())).willReturn(true);
+        given(childDateOfBirthCalculator.hadChildrenUnderFourAtGivenDate(any(), any())).willReturn(true);
+
+        //Given - their children would still be under 4 but DWP doesn't return them if they're NOT_CONFIRMED.
+        Claim claimAtPreviousCycle = aClaimWithExpectedDeliveryDateAndChildrenDobs(previousCycleExpectedDeliveryDate, previousCycleChildrenDobs);
+        List<LocalDate> currentCycleChildrenDobs = NO_CHILDREN;
+        Claim claimAtCurrentCycle = aClaimWithExpectedDeliveryDateAndChildrenDobs(currentCycleExpectedDeliveryDate, currentCycleChildrenDobs);
+        PaymentCycle currentPaymentCycle = aPaymentCycleWithClaim(claimAtCurrentCycle);
+        LocalDate previousCycleStartDate = LocalDate.now().minusWeeks(4);
+        PaymentCycle previousPaymentCycle = aPaymentCycleWithStartDateAndClaim(previousCycleStartDate, claimAtPreviousCycle);
+
+        EligibilityAndEntitlementDecision decision = aDecisionWithStatusAndChildren(INELIGIBLE, NOT_CONFIRMED, currentCycleChildrenDobs);
+        given(pregnancyEntitlementCalculator.isEntitledToVoucher(any(), any())).willReturn(false);
+
+        //When
+        handler.handleIneligibleDecision(claimAtCurrentCycle, previousPaymentCycle, currentPaymentCycle, decision);
+
+        //Then
+        verifyClaimSavedWithStatus(ClaimStatus.PENDING_EXPIRY, PENDING_CANCELLATION);
+        verify(determineEntitlementNotificationHandler).sendClaimNoLongerEligibleEmail(claimAtCurrentCycle);
+        LocalDate currentCycleStartDate = currentPaymentCycle.getCycleStartDate();
+        verify(childDateOfBirthCalculator).hadChildrenUnder4AtStartOfPaymentCycle(previousPaymentCycle);
+        verify(childDateOfBirthCalculator).hadChildrenUnderFourAtGivenDate(ONE_CHILD_UNDER_ONE_AND_ONE_CHILD_BETWEEN_ONE_AND_FOUR, currentCycleStartDate);
+        verify(pregnancyEntitlementCalculator).isEntitledToVoucher(currentCycleExpectedDeliveryDate, currentCycleStartDate);
+        verify(claimMessageSender).sendReportClaimMessage(claimAtCurrentCycle, currentCycleChildrenDobs, UPDATED_FROM_ACTIVE_TO_PENDING_EXPIRY);
+        verifyNoMoreInteractions(childDateOfBirthCalculator, eventAuditor);
+    }
+
+    //HTBHF-1757 No children in current cycle, are pregnant but ineligible from DWP
+    @ParameterizedTest(name = "Children DOB in previous cycle={0}")
+    @MethodSource("provideArgumentsForChildrenInPreviousCycle")
+    void shouldUpdateClaimToPendingExpiryWhenClaimantIsNotEligibleButStillPregnant(List<LocalDate> previousCycleChildrenDobs) {
+        //Given
+        given(pregnancyEntitlementCalculator.isEntitledToVoucher(any(), any())).willReturn(true);
+
+        List<LocalDate> currentCycleChildrenDobs = NO_CHILDREN;
+        Claim claimAtPreviousCycle = aClaimWithExpectedDeliveryDateAndChildrenDobs(EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS, previousCycleChildrenDobs);
+        Claim claimAtCurrentCycle = aClaimWithExpectedDeliveryDateAndChildrenDobs(EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS, currentCycleChildrenDobs);
+        PaymentCycle currentPaymentCycle = aPaymentCycleWithClaim(claimAtCurrentCycle);
+        LocalDate previousCycleStartDate = LocalDate.now().minusWeeks(4);
+        PaymentCycle previousPaymentCycle = aPaymentCycleWithStartDateAndClaim(previousCycleStartDate, claimAtPreviousCycle);
+
+        EligibilityAndEntitlementDecision decision = aDecisionWithStatusAndChildren(INELIGIBLE, NOT_CONFIRMED, currentCycleChildrenDobs);
+
+        //When
+        handler.handleIneligibleDecision(claimAtCurrentCycle, previousPaymentCycle, currentPaymentCycle, decision);
+
+        //Then
+        verifyClaimSavedWithStatus(ClaimStatus.PENDING_EXPIRY, PENDING_CANCELLATION);
+        verify(determineEntitlementNotificationHandler).sendClaimNoLongerEligibleEmail(claimAtCurrentCycle);
+        verify(pregnancyEntitlementCalculator).isEntitledToVoucher(EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS, currentPaymentCycle.getCycleStartDate());
+        verify(claimMessageSender).sendReportClaimMessage(claimAtCurrentCycle, currentCycleChildrenDobs, UPDATED_FROM_ACTIVE_TO_PENDING_EXPIRY);
+        verifyNoMoreInteractions(childDateOfBirthCalculator, eventAuditor);
+    }
+
+    @ParameterizedTest(name = "Qualifying benefit status={0}")
+    @ValueSource(strings = {"CONFIRMED", "NOT_CONFIRMED"})
+    void shouldExpireClaimWhenClaimantWasPregnantWithNoChildrenButNoLongerPregnant(QualifyingBenefitEligibilityStatus qualifyingBenefitEligibilityStatus) {
+        //Given
+        //Had children in last cycle who are under 4 at the start of the current payment cycle.
+        given(childDateOfBirthCalculator.hadChildrenUnder4AtStartOfPaymentCycle(any())).willReturn(false);
+
+        List<LocalDate> currentCycleChildrenDobs = NO_CHILDREN;
+        Claim claimAtPreviousCycle = aClaimWithExpectedDeliveryDateAndChildrenDobs(EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS, currentCycleChildrenDobs);
+        Claim claimAtCurrentCycle = aClaimWithExpectedDeliveryDateAndChildrenDobs(NOT_PREGNANT, currentCycleChildrenDobs);
+        PaymentCycle currentPaymentCycle = aPaymentCycleWithClaim(claimAtCurrentCycle);
+        LocalDate previousCycleStartDate = LocalDate.now().minusWeeks(4);
+        PaymentCycle previousPaymentCycle = aPaymentCycleWithStartDateAndClaim(previousCycleStartDate, claimAtPreviousCycle);
+
+        lenient().when(pregnancyEntitlementCalculator.isEntitledToVoucher(NOT_PREGNANT, currentPaymentCycle.getCycleStartDate())).thenReturn(false);
+        lenient().when(pregnancyEntitlementCalculator.isEntitledToVoucher(EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS, previousPaymentCycle.getCycleStartDate()))
+                .thenReturn(true);
+
+        EligibilityAndEntitlementDecision decision = aDecisionWithStatusAndChildren(INELIGIBLE, qualifyingBenefitEligibilityStatus, currentCycleChildrenDobs);
+
+        //When
+        handler.handleIneligibleDecision(claimAtCurrentCycle, previousPaymentCycle, currentPaymentCycle, decision);
+
+        //Then
+        verifyClaimSavedWithStatus(ClaimStatus.EXPIRED, PENDING_CANCELLATION);
+        verify(childDateOfBirthCalculator).hadChildrenUnder4AtStartOfPaymentCycle(previousPaymentCycle);
+        InOrder inOrder = inOrder(pregnancyEntitlementCalculator, pregnancyEntitlementCalculator);
+        inOrder.verify(pregnancyEntitlementCalculator).isEntitledToVoucher(NOT_PREGNANT, currentPaymentCycle.getCycleStartDate());
+        inOrder.verify(pregnancyEntitlementCalculator).isEntitledToVoucher(EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS, previousPaymentCycle.getCycleStartDate());
+        verify(eventAuditor).auditExpiredClaim(claimAtCurrentCycle);
+    }
+
+    //Argument order is: previousCycleChildrenDobs, previousCycleExpectedDeliveryDate, currentCycleExpectedDeliveryDate
+    private static Stream<Arguments> provideArgumentsForPendingExpiryTestsWithChildrenInCurrentCycle() {
+        return Stream.of(
+                Arguments.of(ONE_CHILD_UNDER_ONE_AND_ONE_CHILD_BETWEEN_ONE_AND_FOUR, NOT_PREGNANT, NOT_PREGNANT),
+                Arguments.of(ONE_CHILD_UNDER_ONE_AND_ONE_CHILD_BETWEEN_ONE_AND_FOUR, EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS, EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS)
+        );
+    }
+
+    private static Stream<Arguments> provideArgumentsForChildrenInPreviousCycle() {
+        return Stream.of(
+                Arguments.of(ONE_CHILD_UNDER_ONE_AND_ONE_CHILD_BETWEEN_ONE_AND_FOUR),
+                Arguments.of(NO_CHILDREN)
+        );
+    }
+
+    private static Stream<Arguments> provideArgumentsForPreviousCycleExpectedDeliveryDate() {
+        return Stream.of(
+                Arguments.of(NOT_PREGNANT),
+                Arguments.of(EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS)
+        );
+    }
+
+    private void verifyClaimSavedWithStatus(ClaimStatus claimStatus, CardStatus cardStatus) {
+        ArgumentCaptor<Claim> argumentCaptor = ArgumentCaptor.forClass(Claim.class);
+        verify(claimRepository, times(2)).save(argumentCaptor.capture());
+        List<Claim> claims = argumentCaptor.getAllValues();
+        assertThat(claims.get(0).getClaimStatus()).isEqualTo(claimStatus);
+        assertThat(claims.get(1).getCardStatus()).isEqualTo(cardStatus);
+    }
+}

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/processor/DetermineEntitlementMessageProcessorTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/processor/DetermineEntitlementMessageProcessorTest.java
@@ -2,18 +2,10 @@ package uk.gov.dhsc.htbhf.claimant.message.processor;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.dhsc.htbhf.claimant.communications.DetermineEntitlementNotificationHandler;
-import uk.gov.dhsc.htbhf.claimant.entitlement.PregnancyEntitlementCalculator;
-import uk.gov.dhsc.htbhf.claimant.entity.CardStatus;
+import uk.gov.dhsc.htbhf.claimant.entitlement.IneligibleEntitlementDecisionHandler;
 import uk.gov.dhsc.htbhf.claimant.entity.Claim;
 import uk.gov.dhsc.htbhf.claimant.entity.Message;
 import uk.gov.dhsc.htbhf.claimant.entity.PaymentCycle;
@@ -24,42 +16,28 @@ import uk.gov.dhsc.htbhf.claimant.message.MessageType;
 import uk.gov.dhsc.htbhf.claimant.message.context.DetermineEntitlementMessageContext;
 import uk.gov.dhsc.htbhf.claimant.message.context.MessageContextLoader;
 import uk.gov.dhsc.htbhf.claimant.message.payload.MessagePayload;
-import uk.gov.dhsc.htbhf.claimant.model.ClaimStatus;
 import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityAndEntitlementDecision;
-import uk.gov.dhsc.htbhf.claimant.model.eligibility.QualifyingBenefitEligibilityStatus;
-import uk.gov.dhsc.htbhf.claimant.repository.ClaimRepository;
-import uk.gov.dhsc.htbhf.claimant.service.ClaimMessageSender;
 import uk.gov.dhsc.htbhf.claimant.service.EligibilityAndEntitlementService;
-import uk.gov.dhsc.htbhf.claimant.service.audit.EventAuditor;
 import uk.gov.dhsc.htbhf.claimant.service.payments.PaymentCycleService;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.internal.verification.VerificationModeFactory.times;
-import static uk.gov.dhsc.htbhf.claimant.entity.CardStatus.PENDING_CANCELLATION;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static uk.gov.dhsc.htbhf.claimant.message.MessageStatus.COMPLETED;
 import static uk.gov.dhsc.htbhf.claimant.message.MessageType.DETERMINE_ENTITLEMENT;
-import static uk.gov.dhsc.htbhf.claimant.model.eligibility.QualifyingBenefitEligibilityStatus.CONFIRMED;
-import static uk.gov.dhsc.htbhf.claimant.model.eligibility.QualifyingBenefitEligibilityStatus.NOT_CONFIRMED;
-import static uk.gov.dhsc.htbhf.claimant.reporting.ClaimAction.UPDATED_FROM_ACTIVE_TO_EXPIRED;
-import static uk.gov.dhsc.htbhf.claimant.reporting.ClaimAction.UPDATED_FROM_ACTIVE_TO_PENDING_EXPIRY;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimTestDataFactory.aClaimWithExpectedDeliveryDateAndChildrenDobs;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.EligibilityAndEntitlementTestDataFactory.aDecisionWithStatus;
-import static uk.gov.dhsc.htbhf.claimant.testsupport.EligibilityAndEntitlementTestDataFactory.aDecisionWithStatusAndChildren;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.MessageContextTestDataFactory.aDetermineEntitlementMessageContext;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.MessageTestDataFactory.aValidMessageWithType;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aPaymentCycleWithClaim;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aPaymentCycleWithStartDateAndClaim;
-import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.*;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.ONE_CHILD_UNDER_ONE_AND_ONE_CHILD_BETWEEN_ONE_AND_FOUR;
 import static uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus.ELIGIBLE;
 import static uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus.INELIGIBLE;
 
@@ -73,19 +51,9 @@ class DetermineEntitlementMessageProcessorTest {
     @Mock
     private PaymentCycleService paymentCycleService;
     @Mock
-    private ClaimRepository claimRepository;
-    @Mock
     private MessageQueueClient messageQueueClient;
     @Mock
-    private DetermineEntitlementNotificationHandler determineEntitlementNotificationHandler;
-    @Mock
-    private PregnancyEntitlementCalculator pregnancyEntitlementCalculator;
-    @Mock
-    private ChildDateOfBirthCalculator childDateOfBirthCalculator;
-    @Mock
-    private EventAuditor eventAuditor;
-    @Mock
-    private ClaimMessageSender claimMessageSender;
+    private IneligibleEntitlementDecisionHandler ineligibleEntitlementDecisionHandler;
 
     @InjectMocks
     private DetermineEntitlementMessageProcessor processor;
@@ -120,150 +88,20 @@ class DetermineEntitlementMessageProcessorTest {
         verify(paymentCycleService).updatePaymentCycle(context.getCurrentPaymentCycle(), decision);
         MessagePayload expectedPayload = MessagePayloadFactory.buildMakePaymentMessagePayload(context.getCurrentPaymentCycle());
         verify(messageQueueClient).sendMessage(expectedPayload, MessageType.MAKE_PAYMENT);
-        verifyZeroInteractions(claimRepository, pregnancyEntitlementCalculator, childDateOfBirthCalculator,
-                childDateOfBirthCalculator, eventAuditor, claimMessageSender);
+        verifyNoMoreInteractions(ineligibleEntitlementDecisionHandler);
     }
 
-    @ParameterizedTest(name = "Qualifying benefit status={0}")
-    @ValueSource(strings = {"CONFIRMED", "NOT_CONFIRMED"})
-    void shouldExpireClaimWhenIneligibleWithNoChildrenAndNotPregnant(QualifyingBenefitEligibilityStatus qualifyingBenefitEligibilityStatus) {
+    @Test
+    void shouldSuccessfullyProcessMessageAndHandleIneligibleDecision() {
         //Given
-        //Test for HTBHF-2182 has the following context:
-        // Previous cycle: children exist and are under 4 but will be 4 in the next cycle, not pregnant
-        // Current cycle: no children and not pregnant
-        List<LocalDate> currentCycleChildrenDobs = NO_CHILDREN;
-        DetermineEntitlementMessageContext context = buildMessageContext(
-                NOT_PREGNANT,
-                SINGLE_NEARLY_FOUR_YEAR_OLD,
-                NOT_PREGNANT,
-                currentCycleChildrenDobs);
-        given(messageContextLoader.loadDetermineEntitlementContext(any())).willReturn(context);
-
-        //Claimant has children under 4 at the previous payment cycle that would still over 4 now (but not reported by DWP).
-        given(childDateOfBirthCalculator.hadChildrenUnder4AtStartOfPaymentCycle(any())).willReturn(true);
-        given(childDateOfBirthCalculator.hadChildrenUnderFourAtGivenDate(any(), any())).willReturn(false);
-
-        //Eligibility is INELIGIBLE as they have no children or pregnancy but did in the previous cycle. DWP status is irrelevant here.
-        EligibilityAndEntitlementDecision decision = aDecisionWithStatusAndChildren(INELIGIBLE, qualifyingBenefitEligibilityStatus, currentCycleChildrenDobs);
-        given(eligibilityAndEntitlementService.evaluateExistingClaimant(any(), any(), any())).willReturn(decision);
-        given(pregnancyEntitlementCalculator.isEntitledToVoucher(any(), any())).willReturn(false);
-
-        //Current payment cycle voucher entitlement mocking
-        Message message = aValidMessageWithType(DETERMINE_ENTITLEMENT);
-
-        //When
-        MessageStatus messageStatus = processor.processMessage(message);
-
-        //Then
-        runCommonVerifications(context, decision, message, messageStatus, ClaimStatus.EXPIRED, PENDING_CANCELLATION);
-        LocalDate currentPaymentCycleStartDate = context.getCurrentPaymentCycle().getCycleStartDate();
-        verify(pregnancyEntitlementCalculator).isEntitledToVoucher(NOT_PREGNANT, currentPaymentCycleStartDate);
-        verify(childDateOfBirthCalculator).hadChildrenUnder4AtStartOfPaymentCycle(context.getPreviousPaymentCycle());
-        verify(childDateOfBirthCalculator).hadChildrenUnderFourAtGivenDate(SINGLE_NEARLY_FOUR_YEAR_OLD, currentPaymentCycleStartDate);
-        verify(eventAuditor).auditExpiredClaim(context.getClaim());
-        verify(claimMessageSender).sendReportClaimMessage(context.getClaim(), currentCycleChildrenDobs, UPDATED_FROM_ACTIVE_TO_EXPIRED);
-        verifyZeroInteractions(messageQueueClient, determineEntitlementNotificationHandler);
-    }
-
-    @ParameterizedTest(name = "Expected delivery date previous cycle={0}")
-    @MethodSource("provideArgumentsForPreviousCycleExpectedDeliveryDate")
-    void shouldExpireClaimWhenChildDisappearsFromFeedAndNotPregnant(LocalDate previousCycleExpectedDeliveryDate) {
-        //Given
-        //Test for HTBHF-2185 has the following context:
-        // Previous cycle: children exist and are under 4, not pregnant or pregnant (parameterised)
-        // Current cycle: no children and not pregnant
-        List<LocalDate> currentCycleChildrenDobs = NO_CHILDREN;
-        DetermineEntitlementMessageContext context = buildMessageContext(
-                previousCycleExpectedDeliveryDate,
-                SINGLE_THREE_YEAR_OLD,
-                NOT_PREGNANT,
-                currentCycleChildrenDobs);
-        given(messageContextLoader.loadDetermineEntitlementContext(any())).willReturn(context);
-
-        //Claimant has children under 4 at the previous payment cycle that would still be under 4 now (but not reported by DWP).
-        given(childDateOfBirthCalculator.hadChildrenUnder4AtStartOfPaymentCycle(any())).willReturn(true);
-        given(childDateOfBirthCalculator.hadChildrenUnderFourAtGivenDate(any(), any())).willReturn(true);
-
-        //Eligibility is INELIGIBLE as they have no children or pregnancy but DWP have returned that they are eligible (CONFIRMED)
-        EligibilityAndEntitlementDecision decision = aDecisionWithStatusAndChildren(INELIGIBLE, CONFIRMED, currentCycleChildrenDobs);
-        given(eligibilityAndEntitlementService.evaluateExistingClaimant(any(), any(), any())).willReturn(decision);
-        given(pregnancyEntitlementCalculator.isEntitledToVoucher(any(), any())).willReturn(false);
-
-        //Current payment cycle voucher entitlement mocking
-        Message message = aValidMessageWithType(DETERMINE_ENTITLEMENT);
-
-        //When
-        MessageStatus messageStatus = processor.processMessage(message);
-
-        //Then
-        runCommonVerifications(context, decision, message, messageStatus, ClaimStatus.EXPIRED, PENDING_CANCELLATION);
-        verify(determineEntitlementNotificationHandler).sendNoChildrenOnFeedClaimNoLongerEligibleEmail(context.getClaim());
-        LocalDate currentPaymentCycleStartDate = context.getCurrentPaymentCycle().getCycleStartDate();
-        verify(pregnancyEntitlementCalculator).isEntitledToVoucher(NOT_PREGNANT, currentPaymentCycleStartDate);
-        verify(childDateOfBirthCalculator).hadChildrenUnder4AtStartOfPaymentCycle(context.getPreviousPaymentCycle());
-        verify(childDateOfBirthCalculator).hadChildrenUnderFourAtGivenDate(SINGLE_THREE_YEAR_OLD, currentPaymentCycleStartDate);
-        verify(eventAuditor).auditExpiredClaim(context.getClaim());
-        verify(claimMessageSender).sendReportClaimMessage(context.getClaim(), currentCycleChildrenDobs, UPDATED_FROM_ACTIVE_TO_EXPIRED);
-        verifyZeroInteractions(messageQueueClient);
-    }
-
-    //HTBHF-1757 Children in current cycle, DWP returns ineligible, varying on pregnancy and children in previous cycle
-    @ParameterizedTest(name = "Children DOB previous cycle={0}, expected delivery date previous cycle={1}, expected delivery date current cycle={2}")
-    @MethodSource("provideArgumentsForPendingExpiryTestsWithChildrenInCurrentCycle")
-    void shouldUpdateClaimToPendingExpiryWhenClaimantIsNotEligibleWithChildrenInCurrentCycle(
-            List<LocalDate> previousCycleChildrenDobs,
-            LocalDate previousCycleExpectedDeliveryDate,
-            LocalDate currentCycleExpectedDeliveryDate) {
-        //Given - their children would still be under 4 but DWP doesn't return them if they're NOT_CONFIRMED.
-        List<LocalDate> currentCycleChildrenDobs = NO_CHILDREN;
-        DetermineEntitlementMessageContext context = buildMessageContext(
-                previousCycleExpectedDeliveryDate,
-                previousCycleChildrenDobs,
-                currentCycleExpectedDeliveryDate,
-                currentCycleChildrenDobs);
-        given(messageContextLoader.loadDetermineEntitlementContext(any())).willReturn(context);
-
-        //Eligibility - any status that isn't ELIGIBLE has the same effect here.
-        EligibilityAndEntitlementDecision decision = aDecisionWithStatusAndChildren(INELIGIBLE, NOT_CONFIRMED, currentCycleChildrenDobs);
-        given(eligibilityAndEntitlementService.evaluateExistingClaimant(any(), any(), any())).willReturn(decision);
-        given(pregnancyEntitlementCalculator.isEntitledToVoucher(any(), any())).willReturn(false);
-        //Had children in last cycle who are under 4 at the start of the current payment cycle.
-        given(childDateOfBirthCalculator.hadChildrenUnder4AtStartOfPaymentCycle(any())).willReturn(true);
-        given(childDateOfBirthCalculator.hadChildrenUnderFourAtGivenDate(any(), any())).willReturn(true);
-
-        //Current payment cycle voucher entitlement mocking
-        Message message = aValidMessageWithType(DETERMINE_ENTITLEMENT);
-
-        //When
-        MessageStatus messageStatus = processor.processMessage(message);
-
-        //Then
-        runCommonVerifications(context, decision, message, messageStatus, ClaimStatus.PENDING_EXPIRY, PENDING_CANCELLATION);
-        verify(determineEntitlementNotificationHandler).sendClaimNoLongerEligibleEmail(context.getClaim());
-        LocalDate currentCycleStartDate = context.getCurrentPaymentCycle().getCycleStartDate();
-        verify(childDateOfBirthCalculator).hadChildrenUnder4AtStartOfPaymentCycle(context.getPreviousPaymentCycle());
-        verify(childDateOfBirthCalculator).hadChildrenUnderFourAtGivenDate(ONE_CHILD_UNDER_ONE_AND_ONE_CHILD_BETWEEN_ONE_AND_FOUR, currentCycleStartDate);
-        verify(pregnancyEntitlementCalculator).isEntitledToVoucher(currentCycleExpectedDeliveryDate, currentCycleStartDate);
-        verify(claimMessageSender).sendReportClaimMessage(context.getClaim(), currentCycleChildrenDobs, UPDATED_FROM_ACTIVE_TO_PENDING_EXPIRY);
-        verifyZeroInteractions(childDateOfBirthCalculator, eventAuditor);
-    }
-
-    //HTBHF-1757 No children in current cycle, are pregnant but ineligible from DWP
-    @ParameterizedTest(name = "Children DOB in previous cycle={0}")
-    @MethodSource("provideArgumentsForChildrenInPreviousCycle")
-    void shouldUpdateClaimToPendingExpiryWhenClaimantIsNotEligibleButStillPregnant(List<LocalDate> previousCycleChildrenDobs) {
-        //Given
-        List<LocalDate> currentCycleChildrenDobs = NO_CHILDREN;
         DetermineEntitlementMessageContext context = buildMessageContext(
                 EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS,
-                previousCycleChildrenDobs,
+                ONE_CHILD_UNDER_ONE_AND_ONE_CHILD_BETWEEN_ONE_AND_FOUR,
                 EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS,
-                currentCycleChildrenDobs);
+                ONE_CHILD_UNDER_ONE_AND_ONE_CHILD_BETWEEN_ONE_AND_FOUR);
         given(messageContextLoader.loadDetermineEntitlementContext(any())).willReturn(context);
-        given(pregnancyEntitlementCalculator.isEntitledToVoucher(any(), any())).willReturn(true);
 
-        //Eligibility - any status that isn't ELIGIBLE has the same effect here.
-        EligibilityAndEntitlementDecision decision = aDecisionWithStatusAndChildren(INELIGIBLE, NOT_CONFIRMED, currentCycleChildrenDobs);
+        EligibilityAndEntitlementDecision decision = aDecisionWithStatus(INELIGIBLE);
         given(eligibilityAndEntitlementService.evaluateExistingClaimant(any(), any(), any())).willReturn(decision);
 
         //Current payment cycle voucher entitlement mocking
@@ -273,63 +111,6 @@ class DetermineEntitlementMessageProcessorTest {
         MessageStatus messageStatus = processor.processMessage(message);
 
         //Then
-        runCommonVerifications(context, decision, message, messageStatus, ClaimStatus.PENDING_EXPIRY, PENDING_CANCELLATION);
-        verify(determineEntitlementNotificationHandler).sendClaimNoLongerEligibleEmail(context.getClaim());
-        verify(pregnancyEntitlementCalculator).isEntitledToVoucher(EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS, context.getCurrentPaymentCycle().getCycleStartDate());
-        verify(claimMessageSender).sendReportClaimMessage(context.getClaim(), currentCycleChildrenDobs, UPDATED_FROM_ACTIVE_TO_PENDING_EXPIRY);
-        verifyZeroInteractions(childDateOfBirthCalculator, eventAuditor);
-    }
-
-    @ParameterizedTest(name = "Qualifying benefit status={0}")
-    @ValueSource(strings = {"CONFIRMED", "NOT_CONFIRMED"})
-    void shouldExpireClaimWhenClaimantWasPregnantWithNoChildrenButNoLongerPregnant(QualifyingBenefitEligibilityStatus qualifyingBenefitEligibilityStatus) {
-        //Given
-        List<LocalDate> currentCycleChildrenDobs = NO_CHILDREN;
-        DetermineEntitlementMessageContext context = buildMessageContext(
-                EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS,
-                NO_CHILDREN,
-                NOT_PREGNANT,
-                currentCycleChildrenDobs);
-        given(messageContextLoader.loadDetermineEntitlementContext(any())).willReturn(context);
-        LocalDate currentPaymentCycleStartDate = context.getCurrentPaymentCycle().getCycleStartDate();
-        LocalDate previousPaymentCycleStartDate = context.getPreviousPaymentCycle().getCycleStartDate();
-        lenient().when(pregnancyEntitlementCalculator.isEntitledToVoucher(NOT_PREGNANT, currentPaymentCycleStartDate)).thenReturn(false);
-        lenient().when(pregnancyEntitlementCalculator.isEntitledToVoucher(EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS, previousPaymentCycleStartDate))
-                .thenReturn(true);
-        //Had children in last cycle who are under 4 at the start of the current payment cycle.
-        given(childDateOfBirthCalculator.hadChildrenUnder4AtStartOfPaymentCycle(any())).willReturn(false);
-
-        //Eligibility - any status that isn't ELIGIBLE has the same effect here.
-        EligibilityAndEntitlementDecision decision = aDecisionWithStatusAndChildren(INELIGIBLE, qualifyingBenefitEligibilityStatus, currentCycleChildrenDobs);
-        given(eligibilityAndEntitlementService.evaluateExistingClaimant(any(), any(), any())).willReturn(decision);
-
-        //Current payment cycle voucher entitlement mocking
-        Message message = aValidMessageWithType(DETERMINE_ENTITLEMENT);
-
-        //When
-        MessageStatus messageStatus = processor.processMessage(message);
-
-        //Then
-        runCommonVerifications(context, decision, message, messageStatus, ClaimStatus.EXPIRED, PENDING_CANCELLATION);
-        verify(childDateOfBirthCalculator).hadChildrenUnder4AtStartOfPaymentCycle(context.getPreviousPaymentCycle());
-        InOrder inOrder = inOrder(pregnancyEntitlementCalculator, pregnancyEntitlementCalculator);
-        inOrder.verify(pregnancyEntitlementCalculator).isEntitledToVoucher(NOT_PREGNANT, currentPaymentCycleStartDate);
-        inOrder.verify(pregnancyEntitlementCalculator).isEntitledToVoucher(EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS, previousPaymentCycleStartDate);
-        verify(eventAuditor).auditExpiredClaim(context.getClaim());
-        verify(claimMessageSender).sendReportClaimMessage(context.getClaim(), currentCycleChildrenDobs, UPDATED_FROM_ACTIVE_TO_EXPIRED);
-        verifyZeroInteractions(determineEntitlementNotificationHandler, messageQueueClient);
-    }
-
-    private void verifyClaimSavedWithStatus(ClaimStatus claimStatus, CardStatus cardStatus) {
-        ArgumentCaptor<Claim> argumentCaptor = ArgumentCaptor.forClass(Claim.class);
-        verify(claimRepository, times(2)).save(argumentCaptor.capture());
-        List<Claim> claims = argumentCaptor.getAllValues();
-        assertThat(claims.get(0).getClaimStatus()).isEqualTo(claimStatus);
-        assertThat(claims.get(1).getCardStatus()).isEqualTo(cardStatus);
-    }
-
-    private void runCommonVerifications(DetermineEntitlementMessageContext context, EligibilityAndEntitlementDecision decision,
-                                        Message message, MessageStatus messageStatus, ClaimStatus expectedClaimStatus, CardStatus expectedCardStatus) {
         assertThat(messageStatus).isEqualTo(COMPLETED);
         verify(messageContextLoader).loadDetermineEntitlementContext(message);
         verify(eligibilityAndEntitlementService).evaluateExistingClaimant(context.getClaim().getClaimant(),
@@ -337,7 +118,9 @@ class DetermineEntitlementMessageProcessorTest {
                 context.getPreviousPaymentCycle());
 
         verify(paymentCycleService).updatePaymentCycle(context.getCurrentPaymentCycle(), decision);
-        verifyClaimSavedWithStatus(expectedClaimStatus, expectedCardStatus);
+        verify(ineligibleEntitlementDecisionHandler)
+                .handleIneligibleDecision(context.getClaim(), context.getPreviousPaymentCycle(), context.getCurrentPaymentCycle(), decision);
+        verifyNoMoreInteractions(messageQueueClient);
     }
 
     private DetermineEntitlementMessageContext buildMessageContext(LocalDate previousCycleExpectedDeliveryDate,
@@ -360,28 +143,6 @@ class DetermineEntitlementMessageProcessorTest {
                 currentPaymentCycle,
                 previousPaymentCycle,
                 claimAtCurrentCycle);
-    }
-
-    //Argument order is: previousCycleChildrenDobs, previousCycleExpectedDeliveryDate, currentCycleExpectedDeliveryDate
-    private static Stream<Arguments> provideArgumentsForPendingExpiryTestsWithChildrenInCurrentCycle() {
-        return Stream.of(
-                Arguments.of(ONE_CHILD_UNDER_ONE_AND_ONE_CHILD_BETWEEN_ONE_AND_FOUR, NOT_PREGNANT, NOT_PREGNANT),
-                Arguments.of(ONE_CHILD_UNDER_ONE_AND_ONE_CHILD_BETWEEN_ONE_AND_FOUR, EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS, EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS)
-        );
-    }
-
-    private static Stream<Arguments> provideArgumentsForChildrenInPreviousCycle() {
-        return Stream.of(
-                Arguments.of(ONE_CHILD_UNDER_ONE_AND_ONE_CHILD_BETWEEN_ONE_AND_FOUR),
-                Arguments.of(NO_CHILDREN)
-        );
-    }
-
-    private static Stream<Arguments> provideArgumentsForPreviousCycleExpectedDeliveryDate() {
-        return Stream.of(
-                Arguments.of(NOT_PREGNANT),
-                Arguments.of(EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS)
-        );
     }
 
 }


### PR DESCRIPTION
DetermineEntitlementMessageProcessor currently has 10 dependencies and was about to have one more with some upcoming work. It was therefore decided to split out some of the logic into a separate class. Doing this has halved the number of dependencies and allowed us to remove the suppression of PMD's TooManyMethods warning.

Ineligible decisions are now handled in the new IneligibleEntitlementDecisionHandler.

The code and tests have been copied directly from one class to another, no logic has been changed. 