### PR TITLE
HTBHF-2568 Create factory for creating an IdentityAndEligibilityResponse…

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/IdentityAndEligibilityResponseFactory.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/IdentityAndEligibilityResponseFactory.java
@@ -1,0 +1,89 @@
+package uk.gov.dhsc.htbhf.claimant.service;
+
+import org.springframework.util.CollectionUtils;
+import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityResponse;
+import uk.gov.dhsc.htbhf.dwp.model.v2.*;
+import uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+
+/**
+ * Factory object for building IdentityAndEligibilityResponse objects for v1 responses from the
+ * eligibility service.
+ */
+public class IdentityAndEligibilityResponseFactory {
+
+    /**
+     * Builds up an {@link IdentityAndEligibilityResponse} matching the {@link EligibilityResponse} returned from
+     * the v1 version of the eligibility client.
+     *
+     * @param eligibilityResponse The response to use
+     * @return The built response.
+     */
+    public static IdentityAndEligibilityResponse fromEligibilityResponse(EligibilityResponse eligibilityResponse) {
+        EligibilityStatus eligibilityStatus = eligibilityResponse.getEligibilityStatus();
+        IdentityAndEligibilityResponse.IdentityAndEligibilityResponseBuilder builder = setupIdentityAndEligibilityResponseBuilder(eligibilityResponse);
+        if (EligibilityStatus.ELIGIBLE == eligibilityStatus) {
+            buildEligibleResponse(builder, eligibilityResponse);
+        } else if (EligibilityStatus.INELIGIBLE == eligibilityStatus) {
+            buildIneligibleResponse(builder);
+        } else {
+            buildNotMatchedResponse(builder);
+        }
+        return builder.build();
+    }
+
+    private static void buildNotMatchedResponse(IdentityAndEligibilityResponse.IdentityAndEligibilityResponseBuilder builder) {
+        builder
+                .identityStatus(IdentityOutcome.NOT_MATCHED)
+                .eligibilityStatus(EligibilityOutcome.NOT_SET)
+                .qualifyingBenefits(QualifyingBenefits.NOT_SET)
+                .mobilePhoneMatch(VerificationOutcome.NOT_SET)
+                .emailAddressMatch(VerificationOutcome.NOT_SET)
+                .addressLine1Match(VerificationOutcome.NOT_SET)
+                .postcodeMatch(VerificationOutcome.NOT_SET)
+                .pregnantChildDOBMatch(VerificationOutcome.NOT_SET);
+    }
+
+    private static void buildIneligibleResponse(IdentityAndEligibilityResponse.IdentityAndEligibilityResponseBuilder builder) {
+        builder
+                .identityStatus(IdentityOutcome.MATCHED)
+                .eligibilityStatus(EligibilityOutcome.NOT_CONFIRMED)
+                .qualifyingBenefits(QualifyingBenefits.NOT_SET)
+                .mobilePhoneMatch(VerificationOutcome.NOT_SET)
+                .emailAddressMatch(VerificationOutcome.NOT_SET)
+                .addressLine1Match(VerificationOutcome.NOT_SET)
+                .postcodeMatch(VerificationOutcome.NOT_SET)
+                .pregnantChildDOBMatch(VerificationOutcome.NOT_SET);
+    }
+
+    private static void buildEligibleResponse(IdentityAndEligibilityResponse.IdentityAndEligibilityResponseBuilder builder,
+                                              EligibilityResponse eligibilityResponse) {
+        builder
+                .identityStatus(IdentityOutcome.MATCHED)
+                .eligibilityStatus(EligibilityOutcome.CONFIRMED)
+                .qualifyingBenefits(QualifyingBenefits.UNIVERSAL_CREDIT)
+                .mobilePhoneMatch(VerificationOutcome.MATCHED)
+                .emailAddressMatch(VerificationOutcome.MATCHED)
+                .addressLine1Match(VerificationOutcome.MATCHED)
+                .postcodeMatch(VerificationOutcome.MATCHED)
+                .pregnantChildDOBMatch(VerificationOutcome.NOT_SUPPLIED)
+                .dobOfChildrenUnder4(nullSafeGetChildrenDob(eligibilityResponse));
+    }
+
+    private static IdentityAndEligibilityResponse.IdentityAndEligibilityResponseBuilder setupIdentityAndEligibilityResponseBuilder(
+            EligibilityResponse eligibilityResponse) {
+        return IdentityAndEligibilityResponse.builder()
+                .householdIdentifier(eligibilityResponse.getDwpHouseholdIdentifier())
+                .deathVerificationFlag(DeathVerificationFlag.N_A)
+                .dobOfChildrenUnder4(emptyList());
+    }
+
+    private static List<LocalDate> nullSafeGetChildrenDob(EligibilityResponse eligibilityResponse) {
+        List<LocalDate> dateOfBirthOfChildren = eligibilityResponse.getDateOfBirthOfChildren();
+        return CollectionUtils.isEmpty(dateOfBirthOfChildren) ? emptyList() : dateOfBirthOfChildren;
+    }
+}

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/IdentityAndEligibilityResponseFactoryTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/IdentityAndEligibilityResponseFactoryTest.java
@@ -1,0 +1,68 @@
+package uk.gov.dhsc.htbhf.claimant.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import uk.gov.dhsc.htbhf.claimant.model.eligibility.ChildDTO;
+import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityResponse;
+import uk.gov.dhsc.htbhf.dwp.model.v2.IdentityAndEligibilityResponse;
+import uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.dhsc.htbhf.claimant.service.IdentityAndEligibilityResponseFactory.fromEligibilityResponse;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.EligibilityResponseTestDataFactory.anEligibilityResponseWithChildrenAndStatus;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.EligibilityResponseTestDataFactory.anEligibilityResponseWithStatus;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.EligibilityResponseTestDataFactory.childrenWithBirthdates;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.DWP_HOUSEHOLD_IDENTIFIER;
+import static uk.gov.dhsc.htbhf.dwp.model.v2.VerificationOutcome.NOT_SUPPLIED;
+import static uk.gov.dhsc.htbhf.dwp.testhelper.TestConstants.TWO_CHILDREN;
+import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory.anIdentityMatchFailedResponse;
+import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches;
+import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityNotConfirmedResponse;
+
+class IdentityAndEligibilityResponseFactoryTest {
+
+    @Test
+    void shouldBuildMatchedResponseFromEligibilityResponse() {
+        //Given
+        List<ChildDTO> children = childrenWithBirthdates(TWO_CHILDREN);
+        EligibilityResponse eligibilityResponse = anEligibilityResponseWithChildrenAndStatus(children, EligibilityStatus.ELIGIBLE);
+        //When
+        IdentityAndEligibilityResponse identityAndEligibilityResponse = fromEligibilityResponse(eligibilityResponse);
+        //Then
+        IdentityAndEligibilityResponse expectedResponse = addHouseholdIdentifierToResponse(
+                anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(NOT_SUPPLIED, TWO_CHILDREN));
+        assertThat(identityAndEligibilityResponse).isEqualTo(expectedResponse);
+    }
+
+    @Test
+    void shouldBuildNotMatchedResponseFromEligibilityResponse() {
+        //Given
+        EligibilityResponse eligibilityResponse = anEligibilityResponseWithStatus(EligibilityStatus.INELIGIBLE);
+        //When
+        IdentityAndEligibilityResponse identityAndEligibilityResponse = fromEligibilityResponse(eligibilityResponse);
+        //Then
+        IdentityAndEligibilityResponse expectedResponse = addHouseholdIdentifierToResponse(anIdentityMatchedEligibilityNotConfirmedResponse());
+        assertThat(identityAndEligibilityResponse).isEqualTo(expectedResponse);
+    }
+
+    @ValueSource(strings = {"PENDING", "NO_MATCH", "ERROR", "DUPLICATE"})
+    @ParameterizedTest
+    void shouldBuildNotMatchedResponseFromEligibilityResponse(EligibilityStatus eligibilityStatus) {
+        //Given
+        EligibilityResponse eligibilityResponse = anEligibilityResponseWithStatus(eligibilityStatus);
+        //When
+        IdentityAndEligibilityResponse identityAndEligibilityResponse = fromEligibilityResponse(eligibilityResponse);
+        //Then
+        IdentityAndEligibilityResponse expectedResponse = addHouseholdIdentifierToResponse(anIdentityMatchFailedResponse());
+        assertThat(identityAndEligibilityResponse).isEqualTo(expectedResponse);
+    }
+
+    private IdentityAndEligibilityResponse addHouseholdIdentifierToResponse(IdentityAndEligibilityResponse response) {
+        return response.toBuilder()
+                .householdIdentifier(DWP_HOUSEHOLD_IDENTIFIER)
+                .build();
+    }
+}


### PR DESCRIPTION
…from an EligibilityResponse for v1 requests.

This is not currently used, but will be used by the v1 client to set the IdentityAndEligibilityResponse based on the v1 response. When we have this it means that a IdentityAndEligibilityResponse will be set on all (v1 and v2) responses from the eligibility service.