### PR TITLE
NO-JIRA ensure PaymentCycleEntitlementCalculator copes when no entitlement calculated for previous cycle

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/entitlement/PaymentCycleEntitlementCalculator.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/entitlement/PaymentCycleEntitlementCalculator.java
@@ -108,8 +108,8 @@ public class PaymentCycleEntitlementCalculator {
         return expectedDueDate.isEmpty();
     }
 
-    private boolean noPregnancyVouchers(PaymentCycleVoucherEntitlement vouchersForPregnancy) {
-        return vouchersForPregnancy.getVouchersForPregnancy() == 0;
+    private boolean noPregnancyVouchers(PaymentCycleVoucherEntitlement entitlement) {
+        return entitlement == null || entitlement.getVouchersForPregnancy() == 0;
     }
 
     private boolean isWithinPregnancyMatchPeriod(LocalDate expectedDueDate, LocalDate dateOfBirth) {

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/entitlement/PaymentCycleEntitlementCalculatorTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/entitlement/PaymentCycleEntitlementCalculatorTest.java
@@ -109,6 +109,21 @@ class PaymentCycleEntitlementCalculatorTest {
     }
 
     @Test
+    void shouldCallEntitlementCalculatorWithExpectedDueDateWhenPreviousEntitlementIsNullDueToIneligibilityInPreviousCycle() {
+        VoucherEntitlement voucherEntitlement = aValidVoucherEntitlement();
+        given(entitlementCalculator.calculateVoucherEntitlement(any(), any(), any())).willReturn(voucherEntitlement);
+        List<LocalDate> dateOfBirthsOfChildren = singletonList(LocalDate.now().minusMonths(8));
+        Optional<LocalDate> expectedDueDate = Optional.of(LocalDate.now().plusMonths(8));
+        PaymentCycleVoucherEntitlement previousVoucherEntitlement = null;
+
+        PaymentCycleVoucherEntitlement result =
+                paymentCycleEntitlementCalculator.calculateEntitlement(expectedDueDate, dateOfBirthsOfChildren, LocalDate.now(), previousVoucherEntitlement);
+
+        assertEntitlement(voucherEntitlement, result);
+        verifyEntitlementCalculatorCalled(expectedDueDate, dateOfBirthsOfChildren);
+    }
+
+    @Test
     void shouldGetVoucherEntitlementDatesForCycleStartDate() {
         //Given
         LocalDate startDate = LocalDate.now();


### PR DESCRIPTION
Uncovered during demo preparation. If the claimant was ineligible the previous cycle we get an NPE.