### PR TITLE
HTBHF-2569 Creat interface for EligibilityAndEntitlementService as it…

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/processor/DetermineEntitlementMessageProcessor.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/processor/DetermineEntitlementMessageProcessor.java
@@ -14,8 +14,8 @@ import uk.gov.dhsc.htbhf.claimant.message.context.MessageContextLoader;
 import uk.gov.dhsc.htbhf.claimant.message.payload.MessagePayload;
 import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityAndEntitlementDecision;
 import uk.gov.dhsc.htbhf.claimant.service.ClaimMessageSender;
+import uk.gov.dhsc.htbhf.claimant.service.EligibilityAndEntitlementService;
 import uk.gov.dhsc.htbhf.claimant.service.payments.PaymentCycleService;
-import uk.gov.dhsc.htbhf.claimant.service.v1.EligibilityAndEntitlementService;
 
 import javax.transaction.Transactional;
 

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/ClaimService.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/ClaimService.java
@@ -15,7 +15,6 @@ import uk.gov.dhsc.htbhf.claimant.reporting.ClaimAction;
 import uk.gov.dhsc.htbhf.claimant.repository.ClaimRepository;
 import uk.gov.dhsc.htbhf.claimant.service.audit.EventAuditor;
 import uk.gov.dhsc.htbhf.claimant.service.audit.NewClaimEvent;
-import uk.gov.dhsc.htbhf.claimant.service.v1.EligibilityAndEntitlementService;
 import uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus;
 import uk.gov.dhsc.htbhf.logging.event.FailureEvent;
 

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/EligibilityAndEntitlementService.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/EligibilityAndEntitlementService.java
@@ -1,0 +1,29 @@
+package uk.gov.dhsc.htbhf.claimant.service;
+
+import uk.gov.dhsc.htbhf.claimant.entity.Claimant;
+import uk.gov.dhsc.htbhf.claimant.entity.PaymentCycle;
+import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityAndEntitlementDecision;
+
+import java.time.LocalDate;
+
+public interface EligibilityAndEntitlementService {
+
+    /**
+     * Determines the eligibility and entitlement for the given claimant.
+     *
+     * @param claimant the claimant to check the eligibility for
+     * @return the eligibility and entitlement for the claimant
+     */
+    EligibilityAndEntitlementDecision evaluateClaimant(Claimant claimant);
+
+    /**
+     * Determines the eligibility and entitlement for the given existing claimant.
+     *
+     * @param claimant       the claimant to check the eligibility for
+     * @param cycleStartDate the start date of the payment cycle
+     * @param previousCycle  the previous payment cycle
+     * @return the eligibility and entitlement for the claimant
+     */
+    EligibilityAndEntitlementDecision evaluateExistingClaimant(Claimant claimant, LocalDate cycleStartDate, PaymentCycle previousCycle);
+
+}

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/v1/EligibilityAndEntitlementServiceV1.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/v1/EligibilityAndEntitlementServiceV1.java
@@ -12,6 +12,7 @@ import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityAndEntitlementDec
 import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityResponse;
 import uk.gov.dhsc.htbhf.claimant.repository.ClaimRepository;
 import uk.gov.dhsc.htbhf.claimant.service.DuplicateClaimChecker;
+import uk.gov.dhsc.htbhf.claimant.service.EligibilityAndEntitlementService;
 import uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus;
 
 import java.time.LocalDate;
@@ -22,7 +23,7 @@ import java.util.UUID;
 @Service
 @AllArgsConstructor
 @Slf4j
-public class EligibilityAndEntitlementService {
+public class EligibilityAndEntitlementServiceV1 implements EligibilityAndEntitlementService {
 
     private final EligibilityClient client;
     private final DuplicateClaimChecker duplicateClaimChecker;
@@ -38,6 +39,7 @@ public class EligibilityAndEntitlementService {
      * @param claimant the claimant to check the eligibility for
      * @return the eligibility and entitlement for the claimant
      */
+    @Override
     public EligibilityAndEntitlementDecision evaluateClaimant(Claimant claimant) {
         log.debug("Looking for live claims for the given NINO");
         List<UUID> liveClaimsWithNino = claimRepository.findLiveClaimsWithNino(claimant.getNino());
@@ -74,6 +76,7 @@ public class EligibilityAndEntitlementService {
      * @param previousCycle  the previous payment cycle
      * @return the eligibility and entitlement for the claimant
      */
+    @Override
     public EligibilityAndEntitlementDecision evaluateExistingClaimant(
             Claimant claimant,
             LocalDate cycleStartDate,

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/processor/DetermineEntitlementMessageProcessorTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/processor/DetermineEntitlementMessageProcessorTest.java
@@ -19,8 +19,8 @@ import uk.gov.dhsc.htbhf.claimant.message.context.MessageContextLoader;
 import uk.gov.dhsc.htbhf.claimant.message.payload.MessagePayload;
 import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityAndEntitlementDecision;
 import uk.gov.dhsc.htbhf.claimant.service.ClaimMessageSender;
+import uk.gov.dhsc.htbhf.claimant.service.EligibilityAndEntitlementService;
 import uk.gov.dhsc.htbhf.claimant.service.payments.PaymentCycleService;
-import uk.gov.dhsc.htbhf.claimant.service.v1.EligibilityAndEntitlementService;
 
 import java.time.LocalDate;
 import java.util.List;

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/ClaimServiceTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/ClaimServiceTest.java
@@ -19,7 +19,6 @@ import uk.gov.dhsc.htbhf.claimant.reporting.ClaimAction;
 import uk.gov.dhsc.htbhf.claimant.repository.ClaimRepository;
 import uk.gov.dhsc.htbhf.claimant.service.audit.ClaimEventType;
 import uk.gov.dhsc.htbhf.claimant.service.audit.EventAuditor;
-import uk.gov.dhsc.htbhf.claimant.service.v1.EligibilityAndEntitlementService;
 import uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus;
 import uk.gov.dhsc.htbhf.logging.event.CommonEventType;
 import uk.gov.dhsc.htbhf.logging.event.FailureEvent;
@@ -39,8 +38,8 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static uk.gov.dhsc.htbhf.claimant.model.UpdatableClaimantField.EXPECTED_DELIVERY_DATE;
 import static uk.gov.dhsc.htbhf.claimant.model.UpdatableClaimantField.LAST_NAME;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimDTOTestDataFactory.DEVICE_FINGERPRINT;
@@ -514,7 +513,7 @@ class ClaimServiceTest {
         verify(eventAuditor).auditFailedEvent(eventCaptor.capture());
         assertThat(eventCaptor.getValue().getEventType()).isEqualTo(CommonEventType.FAILURE);
         assertThat(eventCaptor.getValue().getEventMetadata().get(FailureEvent.FAILED_EVENT_KEY)).isEqualTo(ClaimEventType.NEW_CLAIM);
-        verifyZeroInteractions(claimMessageSender);
+        verifyNoInteractions(claimMessageSender);
     }
 
     private void assertClaimCorrectForAudit(ArgumentCaptor<Claim> claimArgumentCaptor, Claimant claimant) {

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/v1/EligibilityAndEntitlementServiceV1Test.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/v1/EligibilityAndEntitlementServiceV1Test.java
@@ -48,10 +48,10 @@ import static uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus.ELIGIBLE;
 import static uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus.INELIGIBLE;
 
 @ExtendWith(MockitoExtension.class)
-class EligibilityAndEntitlementServiceTest {
+class EligibilityAndEntitlementServiceV1Test {
 
     @InjectMocks
-    EligibilityAndEntitlementService eligibilityAndEntitlementService;
+    EligibilityAndEntitlementServiceV1 eligibilityAndEntitlementServiceV1;
 
     @Mock
     EligibilityClient client;
@@ -75,7 +75,7 @@ class EligibilityAndEntitlementServiceTest {
         given(claimRepository.findLiveClaimsWithNino(any())).willReturn(List.of(existingClaimId));
         Claimant claimant = aValidClaimant();
 
-        EligibilityAndEntitlementDecision decision = eligibilityAndEntitlementService.evaluateClaimant(claimant);
+        EligibilityAndEntitlementDecision decision = eligibilityAndEntitlementServiceV1.evaluateClaimant(claimant);
 
         assertCorrectEligibleResult(decision, eligibilityResponse, voucherEntitlement);
         verify(claimRepository).findLiveClaimsWithNino(claimant.getNino());
@@ -93,7 +93,7 @@ class EligibilityAndEntitlementServiceTest {
         given(claimRepository.findLiveClaimsWithNino(any())).willReturn(existingIds);
         Claimant claimant = aValidClaimant();
 
-        MultipleClaimsWithSameNinoException exception = catchThrowableOfType(() -> eligibilityAndEntitlementService.evaluateClaimant(claimant),
+        MultipleClaimsWithSameNinoException exception = catchThrowableOfType(() -> eligibilityAndEntitlementServiceV1.evaluateClaimant(claimant),
                 MultipleClaimsWithSameNinoException.class);
 
         assertThat(exception).isNotNull();
@@ -110,7 +110,7 @@ class EligibilityAndEntitlementServiceTest {
         given(paymentCycleEntitlementCalculator.calculateEntitlement(any(), any(), any())).willReturn(voucherEntitlement);
         Claimant claimant = aValidClaimant();
 
-        EligibilityAndEntitlementDecision result = eligibilityAndEntitlementService.evaluateClaimant(claimant);
+        EligibilityAndEntitlementDecision result = eligibilityAndEntitlementServiceV1.evaluateClaimant(claimant);
 
         assertCorrectIneligibleResultWithNoVoucherEntitlement(result, NOT_CONFIRMED, eligibilityResponse);
         verify(claimRepository).findLiveClaimsWithNino(claimant.getNino());
@@ -132,7 +132,7 @@ class EligibilityAndEntitlementServiceTest {
         given(paymentCycleEntitlementCalculator.calculateEntitlement(any(), any(), any())).willReturn(voucherEntitlement);
         Claimant claimant = aValidClaimant();
 
-        EligibilityAndEntitlementDecision result = eligibilityAndEntitlementService.evaluateClaimant(claimant);
+        EligibilityAndEntitlementDecision result = eligibilityAndEntitlementServiceV1.evaluateClaimant(claimant);
 
         assertCorrectEligibleResult(result, eligibilityResponse, voucherEntitlement);
         verify(claimRepository).findLiveClaimsWithNino(claimant.getNino());
@@ -154,7 +154,7 @@ class EligibilityAndEntitlementServiceTest {
         given(duplicateClaimChecker.liveClaimExistsForHousehold(any())).willReturn(false);
         given(paymentCycleEntitlementCalculator.calculateEntitlement(any(), any(), any())).willReturn(voucherEntitlement);
 
-        EligibilityAndEntitlementDecision result = eligibilityAndEntitlementService.evaluateClaimant(claimant);
+        EligibilityAndEntitlementDecision result = eligibilityAndEntitlementServiceV1.evaluateClaimant(claimant);
 
         assertCorrectIneligibleResultWithNoVoucherEntitlement(result, CONFIRMED, eligibilityResponse);
         verify(claimRepository).findLiveClaimsWithNino(claimant.getNino());
@@ -176,7 +176,7 @@ class EligibilityAndEntitlementServiceTest {
         given(duplicateClaimChecker.liveClaimExistsForHousehold(any())).willReturn(false);
         given(paymentCycleEntitlementCalculator.calculateEntitlement(any(), any(), any())).willReturn(voucherEntitlement);
 
-        EligibilityAndEntitlementDecision result = eligibilityAndEntitlementService.evaluateClaimant(claimant);
+        EligibilityAndEntitlementDecision result = eligibilityAndEntitlementServiceV1.evaluateClaimant(claimant);
 
         assertCorrectIneligibleResultWithNoVoucherEntitlement(result, NOT_CONFIRMED, eligibilityResponse);
         verify(claimRepository).findLiveClaimsWithNino(claimant.getNino());
@@ -198,7 +198,7 @@ class EligibilityAndEntitlementServiceTest {
         given(client.checkEligibility(any())).willReturn(eligibilityResponse);
         given(paymentCycleEntitlementCalculator.calculateEntitlement(any(), any(), any(), any())).willReturn(voucherEntitlement);
 
-        EligibilityAndEntitlementDecision result = eligibilityAndEntitlementService.evaluateExistingClaimant(claimant, cycleStartDate, previousCycle);
+        EligibilityAndEntitlementDecision result = eligibilityAndEntitlementServiceV1.evaluateExistingClaimant(claimant, cycleStartDate, previousCycle);
 
         assertCorrectEligibleResult(result, eligibilityResponse, voucherEntitlement);
         verify(client).checkEligibility(claimant);
@@ -220,7 +220,7 @@ class EligibilityAndEntitlementServiceTest {
         given(client.checkEligibility(any())).willReturn(eligibilityResponse);
         given(paymentCycleEntitlementCalculator.calculateEntitlement(any(), any(), any(), any())).willReturn(voucherEntitlement);
 
-        EligibilityAndEntitlementDecision result = eligibilityAndEntitlementService.evaluateExistingClaimant(claimant, cycleStartDate, previousCycle);
+        EligibilityAndEntitlementDecision result = eligibilityAndEntitlementServiceV1.evaluateExistingClaimant(claimant, cycleStartDate, previousCycle);
 
         assertCorrectIneligibleResultWithNoVoucherEntitlement(result, CONFIRMED, eligibilityResponse);
         verify(client).checkEligibility(claimant);
@@ -242,7 +242,7 @@ class EligibilityAndEntitlementServiceTest {
         Claimant claimant = aValidClaimant();
         given(duplicateClaimChecker.liveClaimExistsForHousehold(eligibilityResponse)).willReturn(true);
 
-        EligibilityAndEntitlementDecision result = eligibilityAndEntitlementService.evaluateClaimant(claimant);
+        EligibilityAndEntitlementDecision result = eligibilityAndEntitlementServiceV1.evaluateClaimant(claimant);
 
         assertCorrectDuplicateResult(result, eligibilityResponse, voucherEntitlement);
         verify(client).checkEligibility(claimant);
@@ -258,7 +258,7 @@ class EligibilityAndEntitlementServiceTest {
         given(client.checkEligibility(any())).willReturn(eligibilityResponse);
         given(paymentCycleEntitlementCalculator.calculateEntitlement(any(), any(), any(), any())).willReturn(voucherEntitlement);
 
-        EligibilityAndEntitlementDecision result = eligibilityAndEntitlementService.evaluateExistingClaimant(claimant, cycleStartDate, previousCycle);
+        EligibilityAndEntitlementDecision result = eligibilityAndEntitlementServiceV1.evaluateExistingClaimant(claimant, cycleStartDate, previousCycle);
 
         assertCorrectIneligibleResultWithNoVoucherEntitlement(result, NOT_CONFIRMED, eligibilityResponse);
         verify(client).checkEligibility(claimant);


### PR DESCRIPTION
… will need to have v1 and v2 implementations.

Existing EligibilityAndEntitlementService has been renamed to EligibilityAndEntitlementServiceV1 and the new interface has taken the original name. We will need to manually manage the creation and injection of the two implementations once V2 is in place in claimant-service, but this will be a few PRs away once the new classes have been created.