### PR TITLE
HTBHF-2641 Added Processor for SaveNewCard message type.

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/MessageType.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/MessageType.java
@@ -2,6 +2,7 @@ package uk.gov.dhsc.htbhf.claimant.message;
 
 public enum MessageType {
     REQUEST_NEW_CARD,
+    SAVE_NEW_CARD,
     MAKE_FIRST_PAYMENT,
     MAKE_PAYMENT,
     SEND_EMAIL,

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/processor/SaveNewCardMessageProcessor.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/processor/SaveNewCardMessageProcessor.java
@@ -1,0 +1,75 @@
+package uk.gov.dhsc.htbhf.claimant.message.processor;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.dhsc.htbhf.claimant.entity.Claim;
+import uk.gov.dhsc.htbhf.claimant.entity.Message;
+import uk.gov.dhsc.htbhf.claimant.entity.PaymentCycle;
+import uk.gov.dhsc.htbhf.claimant.message.MessageQueueClient;
+import uk.gov.dhsc.htbhf.claimant.message.MessageStatus;
+import uk.gov.dhsc.htbhf.claimant.message.MessageType;
+import uk.gov.dhsc.htbhf.claimant.message.MessageTypeProcessor;
+import uk.gov.dhsc.htbhf.claimant.message.context.MessageContextLoader;
+import uk.gov.dhsc.htbhf.claimant.message.context.SaveNewCardMessageContext;
+import uk.gov.dhsc.htbhf.claimant.message.payload.MakePaymentMessagePayload;
+import uk.gov.dhsc.htbhf.claimant.repository.ClaimRepository;
+import uk.gov.dhsc.htbhf.claimant.service.payments.PaymentCycleService;
+
+import javax.transaction.Transactional;
+
+import static uk.gov.dhsc.htbhf.claimant.message.MessagePayloadFactory.buildMakePaymentMessagePayload;
+import static uk.gov.dhsc.htbhf.claimant.message.MessageStatus.COMPLETED;
+import static uk.gov.dhsc.htbhf.claimant.message.MessageType.MAKE_FIRST_PAYMENT;
+import static uk.gov.dhsc.htbhf.claimant.message.MessageType.SAVE_NEW_CARD;
+
+/**
+ * Responsible for processing {@link MessageType#SAVE_NEW_CARD} messages by:
+ * Saving the card account id to the claim,,
+ * Creating a PaymentCycle for the claim,
+ * Sending a {@link MessageType#MAKE_FIRST_PAYMENT} message.
+ */
+@Component
+@AllArgsConstructor
+@Slf4j
+public class SaveNewCardMessageProcessor implements MessageTypeProcessor {
+
+    private MessageContextLoader messageContextLoader;
+    private ClaimRepository claimRepository;
+    private PaymentCycleService paymentCycleService;
+    private MessageQueueClient messageQueueClient;
+
+    @Override
+    public MessageType supportsMessageType() {
+        return SAVE_NEW_CARD;
+    }
+
+    @Override
+    @Transactional(Transactional.TxType.REQUIRES_NEW)
+    public MessageStatus processMessage(Message message) {
+        SaveNewCardMessageContext context = messageContextLoader.loadSaveNewCardContext(message);
+        saveCardAccountIdToClaim(context);
+        PaymentCycle paymentCycle = createAndSavePaymentCycle(context);
+        sendMakeFirstPaymentMessage(paymentCycle);
+        return COMPLETED;
+    }
+
+    private PaymentCycle createAndSavePaymentCycle(SaveNewCardMessageContext context) {
+        Claim claim = context.getClaim();
+        return paymentCycleService.createAndSavePaymentCycleForEligibleClaim(
+                claim,
+                claim.getClaimStatusTimestamp().toLocalDate(),
+                context.getEligibilityAndEntitlementDecision());
+    }
+
+    private void saveCardAccountIdToClaim(SaveNewCardMessageContext context) {
+        Claim claim = context.getClaim();
+        claim.setCardAccountId(context.getCardAccountId());
+        claimRepository.save(claim);
+    }
+
+    private void sendMakeFirstPaymentMessage(PaymentCycle paymentCycle) {
+        MakePaymentMessagePayload messagePayload = buildMakePaymentMessagePayload(paymentCycle);
+        messageQueueClient.sendMessage(messagePayload, MAKE_FIRST_PAYMENT);
+    }
+}

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/scheduler/MessageProcessorScheduler.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/scheduler/MessageProcessorScheduler.java
@@ -62,6 +62,16 @@ public class MessageProcessorScheduler {
 
     @Scheduled(cron = DEFAULT_SCHEDULE)
     @SchedulerLock(
+            name = "Process SAVE_NEW_CARD messages",
+            lockAtLeastForString = MIN_LOCK_TIME,
+            lockAtMostForString = MAX_LOCK_TIME)
+    @NewRequestContextWithSessionId(sessionId = "MessageProcessor:SAVE_NEW_CARD")
+    public void processSaveNewCardMessages() {
+        messageProcessor.processMessagesOfType(MessageType.SAVE_NEW_CARD);
+    }
+
+    @Scheduled(cron = DEFAULT_SCHEDULE)
+    @SchedulerLock(
             name = "Process DETERMINE_ENTITLEMENT messages",
             lockAtLeastForString = MIN_LOCK_TIME,
             lockAtMostForString = MAX_LOCK_TIME)

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/processor/SaveNewCardMessageProcessorTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/processor/SaveNewCardMessageProcessorTest.java
@@ -1,0 +1,113 @@
+package uk.gov.dhsc.htbhf.claimant.message.processor;
+
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.transaction.TestTransaction;
+import uk.gov.dhsc.htbhf.claimant.entity.Claim;
+import uk.gov.dhsc.htbhf.claimant.entity.Message;
+import uk.gov.dhsc.htbhf.claimant.entity.PaymentCycle;
+import uk.gov.dhsc.htbhf.claimant.message.MessageProcessingException;
+import uk.gov.dhsc.htbhf.claimant.message.MessageQueueDAO;
+import uk.gov.dhsc.htbhf.claimant.message.MessageStatus;
+import uk.gov.dhsc.htbhf.claimant.message.MessageType;
+import uk.gov.dhsc.htbhf.claimant.message.context.MessageContextLoader;
+import uk.gov.dhsc.htbhf.claimant.message.context.SaveNewCardMessageContext;
+import uk.gov.dhsc.htbhf.claimant.message.payload.MakePaymentMessagePayload;
+import uk.gov.dhsc.htbhf.claimant.message.payload.MessagePayload;
+import uk.gov.dhsc.htbhf.claimant.repository.ClaimRepository;
+import uk.gov.dhsc.htbhf.claimant.service.payments.PaymentCycleService;
+
+import java.time.LocalDate;
+import javax.transaction.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static uk.gov.dhsc.htbhf.claimant.message.MessageStatus.COMPLETED;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.MessageContextTestDataFactory.aValidSaveNewCardMessageContext;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.MessageTestDataFactory.MESSAGE_PAYLOAD;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.MessageTestDataFactory.aValidMessage;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.MessageTestDataFactory.aValidMessageWithPayload;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aPaymentCycleWithClaim;
+
+@SpringBootTest
+@AutoConfigureEmbeddedDatabase
+@Transactional
+class SaveNewCardMessageProcessorTest {
+
+    @MockBean
+    private MessageContextLoader messageContextLoader;
+    @MockBean
+    private PaymentCycleService paymentCycleService;
+    @MockBean
+    private MessageQueueDAO messageQueueDAO;
+    @MockBean
+    private ClaimRepository claimRepository;
+
+    @Autowired
+    private SaveNewCardMessageProcessor saveNewCardMessageProcessor;
+
+    @Test
+    void shouldRollBackTransactionAndReturnErrorWhenExceptionIsThrown() {
+        //Given
+        MessageProcessingException testException = new MessageProcessingException("Error reading value");
+        given(messageContextLoader.loadSaveNewCardContext(any())).willThrow(testException);
+        Message message = aValidMessageWithPayload(MESSAGE_PAYLOAD);
+
+        //When
+        MessageProcessingException thrown = catchThrowableOfType(
+                () -> saveNewCardMessageProcessor.processMessage(message),
+                MessageProcessingException.class);
+
+        //Then
+        assertThat(thrown).isEqualTo(testException);
+        assertThat(TestTransaction.isFlaggedForRollback()).isTrue();
+        verify(messageContextLoader).loadSaveNewCardContext(message);
+        verifyNoMoreInteractions(claimRepository);
+    }
+
+    @Test
+    void shouldProcessSaveNewCardMessage() {
+        //Given
+        SaveNewCardMessageContext context = aValidSaveNewCardMessageContext();
+        LocalDate cycleStartDate = context.getClaim().getClaimStatusTimestamp().toLocalDate();
+        given(messageContextLoader.loadSaveNewCardContext(any())).willReturn(context);
+        PaymentCycle paymentCycle = aPaymentCycleWithClaim(context.getClaim());
+        given(paymentCycleService.createAndSavePaymentCycleForEligibleClaim(any(), any(), any())).willReturn(paymentCycle);
+        Message message = aValidMessage();
+
+        //When
+        MessageStatus status = saveNewCardMessageProcessor.processMessage(message);
+
+        //Then
+        assertThat(status).isEqualTo(COMPLETED);
+        assertThat(context.getClaim().getCardAccountId()).isEqualTo(context.getCardAccountId());
+        assertThat(TestTransaction.isActive()).isTrue();
+        verify(messageContextLoader).loadSaveNewCardContext(message);
+        verify(claimRepository).save(context.getClaim());
+        verify(paymentCycleService).createAndSavePaymentCycleForEligibleClaim(
+                context.getClaim(),
+                cycleStartDate,
+                context.getEligibilityAndEntitlementDecision());
+        verifyMakeFirstPaymentMessageSent(context.getClaim(), paymentCycle);
+    }
+
+    private void verifyMakeFirstPaymentMessageSent(Claim claim, PaymentCycle paymentCycle) {
+        ArgumentCaptor<MessagePayload> payloadCaptor = ArgumentCaptor.forClass(MessagePayload.class);
+        verify(messageQueueDAO).sendMessage(payloadCaptor.capture(), eq(MessageType.MAKE_FIRST_PAYMENT));
+        assertThat(payloadCaptor.getValue()).isInstanceOf(MakePaymentMessagePayload.class);
+        MakePaymentMessagePayload payload = (MakePaymentMessagePayload) payloadCaptor.getValue();
+        assertThat(payload.getCardAccountId()).isEqualTo(claim.getCardAccountId());
+        assertThat(payload.getClaimId()).isEqualTo(claim.getId());
+        assertThat(payload.getPaymentCycleId()).isEqualTo(paymentCycle.getId());
+    }
+
+}

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/MessageContextTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/MessageContextTestDataFactory.java
@@ -2,15 +2,13 @@ package uk.gov.dhsc.htbhf.claimant.testsupport;
 
 import uk.gov.dhsc.htbhf.claimant.entity.Claim;
 import uk.gov.dhsc.htbhf.claimant.entity.PaymentCycle;
-import uk.gov.dhsc.htbhf.claimant.message.context.AdditionalPregnancyPaymentMessageContext;
-import uk.gov.dhsc.htbhf.claimant.message.context.DetermineEntitlementMessageContext;
-import uk.gov.dhsc.htbhf.claimant.message.context.MakePaymentMessageContext;
-import uk.gov.dhsc.htbhf.claimant.message.context.RequestNewCardMessageContext;
+import uk.gov.dhsc.htbhf.claimant.message.context.*;
 
 import java.util.Optional;
 
 import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimTestDataFactory.aValidClaim;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.EligibilityAndEntitlementTestDataFactory.anEligibleDecision;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.CARD_ACCOUNT_ID;
 
 public class MessageContextTestDataFactory {
 
@@ -37,6 +35,14 @@ public class MessageContextTestDataFactory {
         return RequestNewCardMessageContext.builder()
                 .claim(aValidClaim())
                 .eligibilityAndEntitlementDecision(anEligibleDecision())
+                .build();
+    }
+
+    public static SaveNewCardMessageContext aValidSaveNewCardMessageContext() {
+        return SaveNewCardMessageContext.builder()
+                .claim(aValidClaim())
+                .eligibilityAndEntitlementDecision(anEligibleDecision())
+                .cardAccountId(CARD_ACCOUNT_ID)
                 .build();
     }
 


### PR DESCRIPTION
Added a new processor to handle messages of type SAVE_NEW_CARD. The logic of creating a payment cycle and sending a MAKE_FIRST_PAYMENT message is currently duplicated in RequestNewCardProcesser. This is ok as currently nothing is creating a SAVE_NEW_CARD message. In the next PR the RequestNewCardProcesser will be stripped down to just request the new card then create a SAVE_NEW_CARD message.