### PR TITLE
HTBHF-2570 Modify v2 eligibility and entitlement service to use…

### DIFF
--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/PaymentCycleIntegrationTests.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/PaymentCycleIntegrationTests.java
@@ -286,7 +286,7 @@ class PaymentCycleIntegrationTests extends ScheduledServiceIntegrationTest {
 
         invokeAllSchedulers();
 
-        assertPaymentCycleWithNoPayment(claim, currentPaymentCycleChildrenDobs);
+        assertPaymentCycleWithNoPayment(claim);
 
         assertClaimAndCardStatus(claim, EXPIRED, PENDING_CANCELLATION);
 
@@ -336,9 +336,8 @@ class PaymentCycleIntegrationTests extends ScheduledServiceIntegrationTest {
     @ParameterizedTest(name = "Children DOB previous cycle={0}, Children DOB current cycle={1}, expected delivery date={2}")
     @MethodSource("provideArgumentsForClaimantBecomingIneligibleTest")
     void shouldTestClaimantBecomingIneligible(List<LocalDate> previousCycleChildrenDobs,
-                                              List<LocalDate> currentCycleChildrenDobs,
                                               LocalDate expectedDeliveryDate) throws JsonProcessingException, NotificationClientException {
-        wiremockManager.stubIneligibleEligibilityResponse(currentCycleChildrenDobs);
+        wiremockManager.stubIneligibleEligibilityResponse();
         stubNotificationEmailResponse();
 
         //Create previous PaymentCycle
@@ -346,7 +345,7 @@ class PaymentCycleIntegrationTests extends ScheduledServiceIntegrationTest {
 
         invokeAllSchedulers();
 
-        assertPaymentCycleWithNoPayment(claim, currentCycleChildrenDobs);
+        assertPaymentCycleWithNoPayment(claim);
 
         assertClaimAndCardStatus(claim, PENDING_EXPIRY, PENDING_CANCELLATION);
 
@@ -375,7 +374,7 @@ class PaymentCycleIntegrationTests extends ScheduledServiceIntegrationTest {
 
         invokeAllSchedulers();
 
-        assertPaymentCycleWithNoPayment(claim, currentPaymentCycleChildrenDobs);
+        assertPaymentCycleWithNoPayment(claim);
 
         assertClaimAndCardStatus(claim, EXPIRED, PENDING_CANCELLATION);
 
@@ -408,7 +407,7 @@ class PaymentCycleIntegrationTests extends ScheduledServiceIntegrationTest {
 
         invokeAllSchedulers();
 
-        assertPaymentCycleWithNoPayment(claim, currentPaymentCycleChildrenDobs);
+        assertPaymentCycleWithNoPayment(claim);
 
         assertClaimAndCardStatus(claim, EXPIRED, PENDING_CANCELLATION);
 
@@ -443,7 +442,7 @@ class PaymentCycleIntegrationTests extends ScheduledServiceIntegrationTest {
 
         invokeAllSchedulers();
 
-        assertPaymentCycleWithNoPayment(claim, currentCycleChildrenDobs);
+        assertPaymentCycleWithNoPayment(claim);
 
         assertClaimAndCardStatus(claim, EXPIRED, PENDING_CANCELLATION);
 
@@ -477,7 +476,7 @@ class PaymentCycleIntegrationTests extends ScheduledServiceIntegrationTest {
 
         invokeAllSchedulers();
 
-        assertPaymentCycleWithNoPayment(claim, currentCycleChildrenDobs);
+        assertPaymentCycleWithNoPayment(claim);
 
         assertClaimStatus(claim, PENDING_EXPIRY);
 
@@ -488,14 +487,14 @@ class PaymentCycleIntegrationTests extends ScheduledServiceIntegrationTest {
         verifyNoMoreInteractions(notificationClient);
     }
 
-    //First argument is the previous cycle, second argument is the current cycle, third is the expected delivery date.
+    //First argument is the previous cycle, second is the expected delivery date.
     private static Stream<Arguments> provideArgumentsForClaimantBecomingIneligibleTest() {
         return Stream.of(
-                Arguments.of(SINGLE_THREE_YEAR_OLD, SINGLE_THREE_YEAR_OLD, EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS),
-                Arguments.of(NO_CHILDREN, SINGLE_THREE_YEAR_OLD, EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS),
-                Arguments.of(SINGLE_THREE_YEAR_OLD, NO_CHILDREN, EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS),
-                Arguments.of(NO_CHILDREN, NO_CHILDREN, EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS),
-                Arguments.of(SINGLE_THREE_YEAR_OLD, NO_CHILDREN, NOT_PREGNANT)
+                Arguments.of(SINGLE_THREE_YEAR_OLD, EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS),
+                Arguments.of(NO_CHILDREN, EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS),
+                Arguments.of(SINGLE_THREE_YEAR_OLD, EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS),
+                Arguments.of(NO_CHILDREN, EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS),
+                Arguments.of(SINGLE_THREE_YEAR_OLD, NOT_PREGNANT)
         );
     }
 
@@ -569,11 +568,11 @@ class PaymentCycleIntegrationTests extends ScheduledServiceIntegrationTest {
         assertThat(payment.getPaymentAmountInPence()).isEqualTo(expectedVoucherEntitlement.getTotalVoucherValueInPence());
     }
 
-    private void assertPaymentCycleWithNoPayment(Claim claim, List<LocalDate> childrenDob) {
+    private void assertPaymentCycleWithNoPayment(Claim claim) {
         PaymentCycle paymentCycle = repositoryMediator.getCurrentPaymentCycleForClaim(claim);
         assertThat(paymentCycle.getCycleStartDate()).isEqualTo(LocalDate.now());
         assertThat(paymentCycle.getCycleEndDate()).isEqualTo(LocalDate.now().plusDays(27));
-        assertThat(paymentCycle.getChildrenDob()).isEqualTo(childrenDob);
+        assertThat(paymentCycle.getChildrenDob()).isEmpty();
         assertThat(paymentCycle.getVoucherEntitlement()).isNull();
         assertThat(paymentCycle.getPaymentCycleStatus()).isEqualTo(PaymentCycleStatus.INELIGIBLE);
         assertThat(paymentCycle.getCardBalanceInPence()).isNull();

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/EligibilityAndEntitlementDecisionFactoryTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/EligibilityAndEntitlementDecisionFactoryTest.java
@@ -25,40 +25,39 @@ class EligibilityAndEntitlementDecisionFactoryTest {
     private static final boolean DUPLICATE = true;
     private EligibilityAndEntitlementDecisionFactory factory = new EligibilityAndEntitlementDecisionFactory();
     private IdentityAndEligibilityResponse eligibilityResponse = anAllMatchedEligibilityConfirmedUCResponseWithHouseholdIdentifier();
+    private static final UUID EXISTING_CLAIM_UUID = UUID.randomUUID();
 
     @Test
-    void shouldBuildDecisionWithExistingClaimUUID() {
+    void shouldBuildDecisionWithNoHmrcHouseholdIdentifier() {
         //Given
         PaymentCycleVoucherEntitlement entitlement = aPaymentCycleVoucherEntitlementWithVouchers();
-        UUID existingClaimId = UUID.randomUUID();
 
         //When
-        EligibilityAndEntitlementDecision eligibilityAndEntitlementDecision = factory.buildDecision(eligibilityResponse, entitlement, existingClaimId,
+        EligibilityAndEntitlementDecision eligibilityAndEntitlementDecision = factory.buildDecision(eligibilityResponse, entitlement, EXISTING_CLAIM_UUID,
                 Optional.empty(), NOT_DUPLICATE);
 
         //Then
         EligibilityAndEntitlementDecision expectedDecision = aValidDecisionBuilder()
                 .identityAndEligibilityResponse(eligibilityResponse)
-                .existingClaimId(existingClaimId)
+                .existingClaimId(EXISTING_CLAIM_UUID)
                 .hmrcHouseholdIdentifier(null)
                 .build();
         assertThat(eligibilityAndEntitlementDecision).isEqualTo(expectedDecision);
     }
 
     @Test
-    void shouldBuildDecisionWithExistingClaimUUIDAndHmrcHouseholdIdentifier() {
+    void shouldBuildDecisionWithHmrcHouseholdIdentifier() {
         //Given
         PaymentCycleVoucherEntitlement entitlement = aPaymentCycleVoucherEntitlementWithVouchers();
-        UUID existingClaimId = UUID.randomUUID();
 
         //When
-        EligibilityAndEntitlementDecision eligibilityAndEntitlementDecision = factory.buildDecision(eligibilityResponse, entitlement, existingClaimId,
+        EligibilityAndEntitlementDecision eligibilityAndEntitlementDecision = factory.buildDecision(eligibilityResponse, entitlement, EXISTING_CLAIM_UUID,
                 Optional.of(HMRC_HOUSEHOLD_IDENTIFIER), NOT_DUPLICATE);
 
         //Then
         EligibilityAndEntitlementDecision expectedDecision = aValidDecisionBuilder()
                 .identityAndEligibilityResponse(eligibilityResponse)
-                .existingClaimId(existingClaimId)
+                .existingClaimId(EXISTING_CLAIM_UUID)
                 .hmrcHouseholdIdentifier(HMRC_HOUSEHOLD_IDENTIFIER)
                 .build();
         assertThat(eligibilityAndEntitlementDecision).isEqualTo(expectedDecision);
@@ -71,7 +70,7 @@ class EligibilityAndEntitlementDecisionFactoryTest {
 
         //When
         EligibilityAndEntitlementDecision eligibilityAndEntitlementDecision = factory.buildDecision(eligibilityResponse,
-                entitlement, Optional.empty(), NOT_DUPLICATE);
+                entitlement, null, Optional.empty(), NOT_DUPLICATE);
 
         //Then
         EligibilityAndEntitlementDecision expectedDecision = aValidDecisionBuilder()
@@ -88,7 +87,7 @@ class EligibilityAndEntitlementDecisionFactoryTest {
 
         //When
         EligibilityAndEntitlementDecision eligibilityAndEntitlementDecision = factory.buildDecision(eligibilityResponse,
-                entitlement, Optional.empty(), DUPLICATE);
+                entitlement, null, Optional.empty(), DUPLICATE);
 
         //Then
         EligibilityAndEntitlementDecision expectedDecision = aValidDecisionBuilder()
@@ -107,7 +106,7 @@ class EligibilityAndEntitlementDecisionFactoryTest {
 
         //When
         EligibilityAndEntitlementDecision eligibilityAndEntitlementDecision = factory.buildDecision(eligibilityResponse,
-                entitlement, Optional.empty(), NOT_DUPLICATE);
+                entitlement, EXISTING_CLAIM_UUID, Optional.empty(), NOT_DUPLICATE);
 
         //Then
         EligibilityAndEntitlementDecision expectedDecision = aValidDecisionBuilder()
@@ -115,6 +114,7 @@ class EligibilityAndEntitlementDecisionFactoryTest {
                 .identityAndEligibilityResponse(eligibilityResponse)
                 .hmrcHouseholdIdentifier(null)
                 .voucherEntitlement(null)
+                .existingClaimId(EXISTING_CLAIM_UUID)
                 .build();
         assertThat(eligibilityAndEntitlementDecision).isEqualTo(expectedDecision);
     }
@@ -127,7 +127,7 @@ class EligibilityAndEntitlementDecisionFactoryTest {
 
         //When
         EligibilityAndEntitlementDecision eligibilityAndEntitlementDecision = factory.buildDecision(identityAndEligibilityResponse, entitlement,
-                Optional.empty(), NOT_DUPLICATE);
+                EXISTING_CLAIM_UUID, Optional.empty(), NOT_DUPLICATE);
 
         //Then
         EligibilityAndEntitlementDecision expectedDecision = aValidDecisionBuilder()
@@ -137,6 +137,7 @@ class EligibilityAndEntitlementDecisionFactoryTest {
                 .hmrcHouseholdIdentifier(null)
                 .voucherEntitlement(null)
                 .dateOfBirthOfChildren(emptyList())
+                .existingClaimId(EXISTING_CLAIM_UUID)
                 .build();
         assertThat(eligibilityAndEntitlementDecision).isEqualTo(expectedDecision);
     }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/IdAndEligibilityResponseTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/IdAndEligibilityResponseTestDataFactory.java
@@ -1,6 +1,10 @@
 package uk.gov.dhsc.htbhf.claimant.testsupport;
 
 import uk.gov.dhsc.htbhf.dwp.model.v2.IdentityAndEligibilityResponse;
+import uk.gov.dhsc.htbhf.dwp.model.v2.VerificationOutcome;
+
+import java.time.LocalDate;
+import java.util.List;
 
 import static uk.gov.dhsc.htbhf.dwp.testhelper.TestConstants.DWP_HOUSEHOLD_IDENTIFIER;
 import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches;
@@ -12,6 +16,11 @@ public class IdAndEligibilityResponseTestDataFactory {
 
     public static IdentityAndEligibilityResponse anAllMatchedEligibilityConfirmedUCResponseWithHouseholdIdentifier() {
         return addHouseholdIdentifier(anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches());
+    }
+
+    public static IdentityAndEligibilityResponse anAllMatchedEligibilityConfirmedUCResponseWithHouseholdIdentifier(List<LocalDate> dateOfBirthOfChildren) {
+        return addHouseholdIdentifier(anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(
+                VerificationOutcome.NOT_SUPPLIED, dateOfBirthOfChildren));
     }
 
     public static IdentityAndEligibilityResponse addHouseholdIdentifier(IdentityAndEligibilityResponse originalResponse) {

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/WiremockManager.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/WiremockManager.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static java.util.Collections.emptyList;
 import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.CardBalanceResponseTestDataFactory.aValidCardBalanceResponse;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.CardRequestTestDataFactory.aCardRequest;
@@ -64,8 +65,8 @@ public class WiremockManager {
         stubEligibilityResponse(childrensDateOfBirth, EligibilityStatus.ELIGIBLE);
     }
 
-    public void stubIneligibleEligibilityResponse(List<LocalDate> childrensDateOfBirth) throws JsonProcessingException {
-        stubEligibilityResponse(childrensDateOfBirth, EligibilityStatus.INELIGIBLE);
+    public void stubIneligibleEligibilityResponse() throws JsonProcessingException {
+        stubEligibilityResponse(emptyList(), EligibilityStatus.INELIGIBLE);
     }
 
     public void stubEligibilityResponse(List<LocalDate> childrensDateOfBirth, EligibilityStatus eligibilityStatus) throws JsonProcessingException {


### PR DESCRIPTION
…EligibilityAndEntitlementDecisionFactory.

This means that we can use the factory for both v1 and v2 services now and the v2 service is quite simple using the same code.

The fix required to the PaymentCycleIntegrationTests was simply that we know the behaviour from DWP is going to be different to what we first thought - in the scenario where the claimant has become INELIGIBLE, they will not sent any children's dates of birth back in the response, so they won't be on the subsequent PaymentCycle.