### PR TITLE
HTBHF-2656 Updated claim in pending expiry acceptance tests

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/payload/EmailType.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/message/payload/EmailType.java
@@ -13,9 +13,7 @@ public enum EmailType {
     CLAIM_NO_LONGER_ELIGIBLE("2c69f4ae-3f42-4e71-b305-247c23affb44"),
     NO_CHILD_ON_FEED_NO_LONGER_ELIGIBLE("8be94eb0-5cd0-4191-8b99-9190f80bcc53"),
     CARD_IS_ABOUT_TO_BE_CANCELLED("c4818a9f-564d-40de-adbf-c8b1a6594d75"),
-    REPORT_A_BIRTH_REMINDER("0c3e273a-3cc0-4420-a7e6-187fe678ee7f"),
-    // TODO HTBHF-1296 add template ID when it exists in Notify
-    CLAIM_CLOSED("TODO");
+    REPORT_A_BIRTH_REMINDER("0c3e273a-3cc0-4420-a7e6-187fe678ee7f");
 
     private String templateId;
 

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/ScheduledServiceIntegrationTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/ScheduledServiceIntegrationTest.java
@@ -138,10 +138,6 @@ abstract class ScheduledServiceIntegrationTest {
         assertThatEmailWithNameOnlyWasSent(claim, CLAIM_NO_LONGER_ELIGIBLE);
     }
 
-    void assertThatClaimClosedEmailWasSent(Claim claim) throws NotificationClientException {
-        assertThatEmailWithNameOnlyWasSent(claim, CLAIM_CLOSED);
-    }
-
     void assertThatNewCardEmailSentCorrectly(Claim claim, PaymentCycle paymentCycle) throws NotificationClientException {
         ArgumentCaptor<Map> mapArgumentCaptor = ArgumentCaptor.forClass(Map.class);
         verify(notificationClient).sendEmail(


### PR DESCRIPTION
The claim in pending expiry integration tests have been updated to assert an email type of `CARD_IS_ABOUT_TO_BE_CANCELLED` is sent and that the card status is `SCHEDULED_FOR_CANCELLATION`.
Removed unused EmailType `CLAIM_CLOSED`