### PR TITLE
HTBHF-2677 Add method to DuplicateClaimChecker for CombinedIdentityAndEligibilityResponse

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/DuplicateClaimChecker.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/DuplicateClaimChecker.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityResponse;
 import uk.gov.dhsc.htbhf.claimant.repository.ClaimRepository;
+import uk.gov.dhsc.htbhf.eligibility.model.CombinedIdentityAndEligibilityResponse;
 
 @Service
 @AllArgsConstructor
@@ -19,9 +20,20 @@ public class DuplicateClaimChecker {
      */
     public boolean liveClaimExistsForHousehold(EligibilityResponse eligibilityResponse) {
         boolean dwpClaimExists = liveClaimExistsForDwpHousehold(eligibilityResponse.getDwpHouseholdIdentifier());
+        boolean hmrcClaimExists = liveClaimExistsForHmrcHousehold(eligibilityResponse.getHmrcHouseholdIdentifier());
 
-        String hmrcHouseholdIdentifier = eligibilityResponse.getHmrcHouseholdIdentifier();
-        boolean hmrcClaimExists = hmrcHouseholdIdentifier != null && claimRepository.liveClaimExistsForHmrcHousehold(hmrcHouseholdIdentifier);
+        return dwpClaimExists || hmrcClaimExists;
+    }
+
+    /**
+     * Determines whether a live (new, active, pending or pending expiry) claim exists for the household identifier returned by the DWP or HMRC.
+     *
+     * @param identityAndEligibilityResponse Identity and Eligibility response containing household identifiers.
+     * @return true if there is already a claim for either of the household identifiers.
+     */
+    public boolean liveClaimExistsForHousehold(CombinedIdentityAndEligibilityResponse identityAndEligibilityResponse) {
+        boolean dwpClaimExists = liveClaimExistsForDwpHousehold(identityAndEligibilityResponse.getDwpHouseholdIdentifier());
+        boolean hmrcClaimExists = liveClaimExistsForHmrcHousehold(identityAndEligibilityResponse.getHmrcHouseholdIdentifier());
 
         return dwpClaimExists || hmrcClaimExists;
     }
@@ -30,10 +42,21 @@ public class DuplicateClaimChecker {
      * Determines whether a live (new, active, pending or pending expiry) claim exists for the given
      * DWP household identifier.
      *
-     * @param dwpHouseholdIdentifier The DWP household identifiers.
+     * @param dwpHouseholdIdentifier The DWP household identifier.
      * @return true if there is already a claim for the DWP household identifier.
      */
     public boolean liveClaimExistsForDwpHousehold(String dwpHouseholdIdentifier) {
         return dwpHouseholdIdentifier != null && claimRepository.liveClaimExistsForDwpHousehold(dwpHouseholdIdentifier);
+    }
+
+    /**
+     * Determines whether a live (new, active, pending or pending expiry) claim exists for the given
+     * HMRC household identifier.
+     *
+     * @param hmrcHouseholdIdentifier The HMRC household identifier.
+     * @return true if there is already a claim for the HMRC household identifier.
+     */
+    public boolean liveClaimExistsForHmrcHousehold(String hmrcHouseholdIdentifier) {
+        return hmrcHouseholdIdentifier != null && claimRepository.liveClaimExistsForHmrcHousehold(hmrcHouseholdIdentifier);
     }
 }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/DuplicateClaimCheckerTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/DuplicateClaimCheckerTest.java
@@ -8,7 +8,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.dhsc.htbhf.claimant.repository.ClaimRepository;
+import uk.gov.dhsc.htbhf.eligibility.model.CombinedIdentityAndEligibilityResponse;
 import uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus;
+import uk.gov.dhsc.htbhf.eligibility.model.testhelper.CombinedIdentityAndEligibilityResponseTestDataFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -22,6 +24,9 @@ import static uk.gov.dhsc.htbhf.claimant.testsupport.EligibilityResponseTestData
 @ExtendWith(MockitoExtension.class)
 class DuplicateClaimCheckerTest {
 
+    private static final CombinedIdentityAndEligibilityResponse ELIGIBLE_RESPONSE =
+            CombinedIdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches();
+
     @InjectMocks
     private DuplicateClaimChecker duplicateClaimChecker;
 
@@ -34,7 +39,7 @@ class DuplicateClaimCheckerTest {
             "true, false",
             "false, true"
     })
-    void shouldReturnTrueForMatchingHouseholds(boolean matchingDwpHouseholdIdentifier, boolean matchingHmrcHouseholdIdentifier) {
+    void shouldReturnTrueForMatchingHouseholdsInEligibilityResponse(boolean matchingDwpHouseholdIdentifier, boolean matchingHmrcHouseholdIdentifier) {
         given(claimRepository.liveClaimExistsForDwpHousehold(anyString())).willReturn(matchingDwpHouseholdIdentifier);
         given(claimRepository.liveClaimExistsForHmrcHousehold(anyString())).willReturn(matchingHmrcHouseholdIdentifier);
 
@@ -45,12 +50,41 @@ class DuplicateClaimCheckerTest {
         verify(claimRepository).liveClaimExistsForHmrcHousehold(HMRC_HOUSEHOLD_IDENTIFIER);
     }
 
+    @ParameterizedTest(name = "Should return duplicate status for matching household identifiers: DWP [{0}] HMRC [{1}]")
+    @CsvSource({
+            "true, true",
+            "true, false",
+            "false, true"
+    })
+    void shouldReturnTrueForMatchingHouseholdsInCombinedResponse(boolean matchingDwpHouseholdIdentifier, boolean matchingHmrcHouseholdIdentifier) {
+        given(claimRepository.liveClaimExistsForDwpHousehold(anyString())).willReturn(matchingDwpHouseholdIdentifier);
+        given(claimRepository.liveClaimExistsForHmrcHousehold(anyString())).willReturn(matchingHmrcHouseholdIdentifier);
+
+        boolean result = duplicateClaimChecker.liveClaimExistsForHousehold(ELIGIBLE_RESPONSE);
+
+        assertThat(result).isTrue();
+        verify(claimRepository).liveClaimExistsForDwpHousehold(DWP_HOUSEHOLD_IDENTIFIER);
+        verify(claimRepository).liveClaimExistsForHmrcHousehold(HMRC_HOUSEHOLD_IDENTIFIER);
+    }
+
     @Test
-    void shouldReturnFalseWhenNoMatchingHousehold() {
+    void shouldReturnFalseWhenNoMatchingHouseholdForEligibilityResponse() {
         given(claimRepository.liveClaimExistsForDwpHousehold(anyString())).willReturn(false);
         given(claimRepository.liveClaimExistsForHmrcHousehold(anyString())).willReturn(false);
 
         boolean result = duplicateClaimChecker.liveClaimExistsForHousehold(anEligibilityResponseWithStatus(EligibilityStatus.ELIGIBLE));
+
+        assertThat(result).isFalse();
+        verify(claimRepository).liveClaimExistsForDwpHousehold(DWP_HOUSEHOLD_IDENTIFIER);
+        verify(claimRepository).liveClaimExistsForHmrcHousehold(HMRC_HOUSEHOLD_IDENTIFIER);
+    }
+
+    @Test
+    void shouldReturnFalseWhenNoMatchingHouseholdForCombinedResponse() {
+        given(claimRepository.liveClaimExistsForDwpHousehold(anyString())).willReturn(false);
+        given(claimRepository.liveClaimExistsForHmrcHousehold(anyString())).willReturn(false);
+
+        boolean result = duplicateClaimChecker.liveClaimExistsForHousehold(ELIGIBLE_RESPONSE);
 
         assertThat(result).isFalse();
         verify(claimRepository).liveClaimExistsForDwpHousehold(DWP_HOUSEHOLD_IDENTIFIER);
@@ -78,8 +112,36 @@ class DuplicateClaimCheckerTest {
     }
 
     @Test
-    void shouldReturnFalseWhenNoHouseholdIdentifier() {
+    void shouldReturnFalseWhenNoDwpHouseholdIdentifier() {
         boolean result = duplicateClaimChecker.liveClaimExistsForDwpHousehold(null);
+
+        assertThat(result).isFalse();
+        verifyNoInteractions(claimRepository);
+    }
+
+    @Test
+    void shouldReturnTrueForMatchingHmrcHousehold() {
+        given(claimRepository.liveClaimExistsForHmrcHousehold(anyString())).willReturn(true);
+
+        boolean result = duplicateClaimChecker.liveClaimExistsForHmrcHousehold(HMRC_HOUSEHOLD_IDENTIFIER);
+
+        assertThat(result).isTrue();
+        verify(claimRepository).liveClaimExistsForHmrcHousehold(HMRC_HOUSEHOLD_IDENTIFIER);
+    }
+
+    @Test
+    void shouldReturnFalseWhenNoMatchingHmrcHousehold() {
+        given(claimRepository.liveClaimExistsForHmrcHousehold(anyString())).willReturn(false);
+
+        boolean result = duplicateClaimChecker.liveClaimExistsForHmrcHousehold(HMRC_HOUSEHOLD_IDENTIFIER);
+
+        assertThat(result).isFalse();
+        verify(claimRepository).liveClaimExistsForHmrcHousehold(HMRC_HOUSEHOLD_IDENTIFIER);
+    }
+
+    @Test
+    void shouldReturnFalseWhenNoHmrcHouseholdIdentifier() {
+        boolean result = duplicateClaimChecker.liveClaimExistsForHmrcHousehold(null);
 
         assertThat(result).isFalse();
         verifyNoInteractions(claimRepository);

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/v2/EligibilityAndEntitlementServiceV2Test.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/v2/EligibilityAndEntitlementServiceV2Test.java
@@ -92,7 +92,7 @@ class EligibilityAndEntitlementServiceV2Test {
     void shouldReturnEligibleWhenNotDuplicateAndEligible() {
         //Given
         setupCommonMocksWithoutClaimId();
-        given(duplicateClaimChecker.liveClaimExistsForHousehold(any())).willReturn(false);
+        given(duplicateClaimChecker.liveClaimExistsForHousehold(any(EligibilityResponse.class))).willReturn(false);
         EligibilityAndEntitlementDecision decisionResponse = setupEligibilityAndEntitlementDecisionFactory(ELIGIBLE);
 
         //When
@@ -110,7 +110,7 @@ class EligibilityAndEntitlementServiceV2Test {
         //Given
         EligibilityResponse eligibilityResponse = anEligibilityResponseWithHmrcHouseholdIdentifier(null);
         setupCommonMocks(eligibilityResponse);
-        given(duplicateClaimChecker.liveClaimExistsForHousehold(any())).willReturn(false);
+        given(duplicateClaimChecker.liveClaimExistsForHousehold(any(EligibilityResponse.class))).willReturn(false);
         EligibilityAndEntitlementDecision decisionResponse = setupEligibilityAndEntitlementDecisionFactory(ELIGIBLE);
 
         //When
@@ -128,7 +128,7 @@ class EligibilityAndEntitlementServiceV2Test {
         //Given
         EligibilityResponse eligibilityResponse = anEligibilityResponseWithDwpHouseholdIdentifier(null);
         setupCommonMocks(eligibilityResponse);
-        given(duplicateClaimChecker.liveClaimExistsForHousehold(any())).willReturn(false);
+        given(duplicateClaimChecker.liveClaimExistsForHousehold(any(EligibilityResponse.class))).willReturn(false);
         EligibilityAndEntitlementDecision decisionResponse = setupEligibilityAndEntitlementDecisionFactory(ELIGIBLE);
 
         //When


### PR DESCRIPTION
Attempting to split down the changes in this sub-task, this isn't currently used by with be by the v3 eligibility service.