### PR TITLE
HTBHF-2677 Change to use CombinedIdentityAndEligibilityResponse from …

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/entity/PaymentCycle.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/entity/PaymentCycle.java
@@ -3,7 +3,7 @@ package uk.gov.dhsc.htbhf.claimant.entity;
 import lombok.*;
 import org.hibernate.annotations.Type;
 import uk.gov.dhsc.htbhf.claimant.entitlement.PaymentCycleVoucherEntitlement;
-import uk.gov.dhsc.htbhf.dwp.model.v2.IdentityAndEligibilityResponse;
+import uk.gov.dhsc.htbhf.eligibility.model.CombinedIdentityAndEligibilityResponse;
 import uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus;
 
 import java.time.LocalDate;
@@ -48,7 +48,7 @@ public class PaymentCycle extends VersionedEntity {
 
     @Column(name = "identity_and_eligibility_response")
     @Type(type = "json")
-    private IdentityAndEligibilityResponse identityAndEligibilityResponse;
+    private CombinedIdentityAndEligibilityResponse identityAndEligibilityResponse;
 
     @Column(name = "voucher_entitlement_json")
     @Type(type = "json")

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/model/eligibility/EligibilityAndEntitlementDecision.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/model/eligibility/EligibilityAndEntitlementDecision.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import org.springframework.util.CollectionUtils;
 import uk.gov.dhsc.htbhf.claimant.entitlement.PaymentCycleVoucherEntitlement;
-import uk.gov.dhsc.htbhf.dwp.model.v2.IdentityAndEligibilityResponse;
+import uk.gov.dhsc.htbhf.eligibility.model.CombinedIdentityAndEligibilityResponse;
 import uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus;
 
 import java.time.LocalDate;
@@ -18,7 +18,7 @@ import java.util.UUID;
 public class EligibilityAndEntitlementDecision {
 
     private final EligibilityStatus eligibilityStatus;
-    private final IdentityAndEligibilityResponse identityAndEligibilityResponse;
+    private final CombinedIdentityAndEligibilityResponse identityAndEligibilityResponse;
     private final UUID existingClaimId;
     private final String dwpHouseholdIdentifier;
     private final String hmrcHouseholdIdentifier;

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/ClaimResult.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/ClaimResult.java
@@ -7,7 +7,7 @@ import uk.gov.dhsc.htbhf.claimant.entitlement.VoucherEntitlement;
 import uk.gov.dhsc.htbhf.claimant.entity.Claim;
 import uk.gov.dhsc.htbhf.claimant.model.UpdatableClaimantField;
 import uk.gov.dhsc.htbhf.claimant.model.VerificationResult;
-import uk.gov.dhsc.htbhf.dwp.model.v2.IdentityAndEligibilityResponse;
+import uk.gov.dhsc.htbhf.eligibility.model.CombinedIdentityAndEligibilityResponse;
 
 import java.util.List;
 import java.util.Optional;
@@ -22,7 +22,7 @@ public class ClaimResult {
     private List<String> updatedFields;
     private VerificationResult verificationResult;
 
-    public static ClaimResult withNoEntitlement(Claim claim, IdentityAndEligibilityResponse identityAndEligibilityResponse) {
+    public static ClaimResult withNoEntitlement(Claim claim, CombinedIdentityAndEligibilityResponse identityAndEligibilityResponse) {
         return ClaimResult.builder()
                 .claim(claim)
                 .voucherEntitlement(Optional.empty())
@@ -31,7 +31,7 @@ public class ClaimResult {
     }
 
     public static ClaimResult withEntitlement(Claim claim, VoucherEntitlement voucherEntitlement,
-                                              IdentityAndEligibilityResponse identityAndEligibilityResponse) {
+                                              CombinedIdentityAndEligibilityResponse identityAndEligibilityResponse) {
         return ClaimResult.builder()
                 .claim(claim)
                 .voucherEntitlement(Optional.of(voucherEntitlement))
@@ -40,7 +40,7 @@ public class ClaimResult {
     }
 
     public static ClaimResult withEntitlementAndUpdatedFields(Claim claim, VoucherEntitlement voucherEntitlement, List<UpdatableClaimantField> updatedFields,
-                                                              IdentityAndEligibilityResponse identityAndEligibilityResponse) {
+                                                              CombinedIdentityAndEligibilityResponse identityAndEligibilityResponse) {
         List<String> updatedFieldsAsStrings = Lists.transform(updatedFields, UpdatableClaimantField::getFieldName);
         return ClaimResult.builder()
                 .claim(claim)
@@ -51,7 +51,7 @@ public class ClaimResult {
                 .build();
     }
 
-    private static VerificationResult buildVerificationResult(IdentityAndEligibilityResponse identityAndEligibilityResponse) {
+    private static VerificationResult buildVerificationResult(CombinedIdentityAndEligibilityResponse identityAndEligibilityResponse) {
         return VerificationResult.builder()
                 .addressLine1Match(identityAndEligibilityResponse.getAddressLine1Match())
                 .deathVerificationFlag(identityAndEligibilityResponse.getDeathVerificationFlag())

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/v2/CombinedIdentityAndEligibilityResponseFactory.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/v2/CombinedIdentityAndEligibilityResponseFactory.java
@@ -3,6 +3,7 @@ package uk.gov.dhsc.htbhf.claimant.service.v2;
 import org.springframework.util.CollectionUtils;
 import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityResponse;
 import uk.gov.dhsc.htbhf.dwp.model.v2.*;
+import uk.gov.dhsc.htbhf.eligibility.model.CombinedIdentityAndEligibilityResponse;
 import uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus;
 
 import java.time.LocalDate;
@@ -11,21 +12,23 @@ import java.util.List;
 import static java.util.Collections.emptyList;
 
 /**
- * Factory object for building IdentityAndEligibilityResponse objects for v1 responses from the
+ * Factory object for building CombinedIdentityAndEligibilityResponse objects for v1 responses from the
  * eligibility service.
  */
-public class IdentityAndEligibilityResponseFactory {
+public class CombinedIdentityAndEligibilityResponseFactory {
+
+    private static final String NO_HOUSEHOLD_IDENTIFIER_SET = "";
 
     /**
-     * Builds up an {@link IdentityAndEligibilityResponse} matching the {@link EligibilityResponse} returned from
+     * Builds up an {@link CombinedIdentityAndEligibilityResponse} matching the {@link EligibilityResponse} returned from
      * the v1 version of the eligibility client.
      *
      * @param eligibilityResponse The response to use
      * @return The built response.
      */
-    public static IdentityAndEligibilityResponse fromEligibilityResponse(EligibilityResponse eligibilityResponse) {
+    public static CombinedIdentityAndEligibilityResponse fromEligibilityResponse(EligibilityResponse eligibilityResponse) {
         EligibilityStatus eligibilityStatus = eligibilityResponse.getEligibilityStatus();
-        IdentityAndEligibilityResponse.IdentityAndEligibilityResponseBuilder builder = setupIdentityAndEligibilityResponseBuilder(eligibilityResponse);
+        CombinedIdentityAndEligibilityResponse.CombinedIdentityAndEligibilityResponseBuilder builder = setupBuilder();
         if (EligibilityStatus.ELIGIBLE == eligibilityStatus) {
             buildEligibleResponse(builder, eligibilityResponse);
         } else if (EligibilityStatus.INELIGIBLE == eligibilityStatus) {
@@ -36,7 +39,7 @@ public class IdentityAndEligibilityResponseFactory {
         return builder.build();
     }
 
-    private static void buildNotMatchedResponse(IdentityAndEligibilityResponse.IdentityAndEligibilityResponseBuilder builder) {
+    private static void buildNotMatchedResponse(CombinedIdentityAndEligibilityResponse.CombinedIdentityAndEligibilityResponseBuilder builder) {
         builder
                 .identityStatus(IdentityOutcome.NOT_MATCHED)
                 .eligibilityStatus(EligibilityOutcome.NOT_SET)
@@ -48,7 +51,7 @@ public class IdentityAndEligibilityResponseFactory {
                 .pregnantChildDOBMatch(VerificationOutcome.NOT_SET);
     }
 
-    private static void buildIneligibleResponse(IdentityAndEligibilityResponse.IdentityAndEligibilityResponseBuilder builder) {
+    private static void buildIneligibleResponse(CombinedIdentityAndEligibilityResponse.CombinedIdentityAndEligibilityResponseBuilder builder) {
         builder
                 .identityStatus(IdentityOutcome.MATCHED)
                 .eligibilityStatus(EligibilityOutcome.NOT_CONFIRMED)
@@ -60,7 +63,7 @@ public class IdentityAndEligibilityResponseFactory {
                 .pregnantChildDOBMatch(VerificationOutcome.NOT_SET);
     }
 
-    private static void buildEligibleResponse(IdentityAndEligibilityResponse.IdentityAndEligibilityResponseBuilder builder,
+    private static void buildEligibleResponse(CombinedIdentityAndEligibilityResponse.CombinedIdentityAndEligibilityResponseBuilder builder,
                                               EligibilityResponse eligibilityResponse) {
         builder
                 .identityStatus(IdentityOutcome.MATCHED)
@@ -71,14 +74,16 @@ public class IdentityAndEligibilityResponseFactory {
                 .addressLine1Match(VerificationOutcome.MATCHED)
                 .postcodeMatch(VerificationOutcome.MATCHED)
                 .pregnantChildDOBMatch(VerificationOutcome.NOT_SUPPLIED)
+                .dwpHouseholdIdentifier(eligibilityResponse.getDwpHouseholdIdentifier())
+                .hmrcHouseholdIdentifier(eligibilityResponse.getHmrcHouseholdIdentifier())
                 .dobOfChildrenUnder4(nullSafeGetChildrenDob(eligibilityResponse));
     }
 
-    private static IdentityAndEligibilityResponse.IdentityAndEligibilityResponseBuilder setupIdentityAndEligibilityResponseBuilder(
-            EligibilityResponse eligibilityResponse) {
-        return IdentityAndEligibilityResponse.builder()
-                .householdIdentifier(eligibilityResponse.getDwpHouseholdIdentifier())
+    private static CombinedIdentityAndEligibilityResponse.CombinedIdentityAndEligibilityResponseBuilder setupBuilder() {
+        return CombinedIdentityAndEligibilityResponse.builder()
                 .deathVerificationFlag(DeathVerificationFlag.N_A)
+                .dwpHouseholdIdentifier(NO_HOUSEHOLD_IDENTIFIER_SET)
+                .hmrcHouseholdIdentifier(NO_HOUSEHOLD_IDENTIFIER_SET)
                 .dobOfChildrenUnder4(emptyList());
     }
 

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/v2/EligibilityAndEntitlementServiceV2.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/v2/EligibilityAndEntitlementServiceV2.java
@@ -19,7 +19,7 @@ import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
 
-import static uk.gov.dhsc.htbhf.claimant.service.v2.IdentityAndEligibilityResponseFactory.fromEligibilityResponse;
+import static uk.gov.dhsc.htbhf.claimant.service.v2.CombinedIdentityAndEligibilityResponseFactory.fromEligibilityResponse;
 
 @Primary
 @Service
@@ -95,7 +95,6 @@ public class EligibilityAndEntitlementServiceV2 implements EligibilityAndEntitle
         return decisionFactory.buildDecision(fromEligibilityResponse(eligibilityResponse),
                 entitlement,
                 null,
-                eligibilityResponse.getHmrcHouseholdIdentifier(),
                 duplicateHouseholdIdentifierFound);
     }
 
@@ -105,7 +104,6 @@ public class EligibilityAndEntitlementServiceV2 implements EligibilityAndEntitle
         return decisionFactory.buildDecision(fromEligibilityResponse(eligibilityResponse),
                 entitlement,
                 existingClaimId,
-                eligibilityResponse.getHmrcHouseholdIdentifier(),
                 false);
     }
 

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/v3/EligibilityClientV3.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/v3/EligibilityClientV3.java
@@ -9,8 +9,8 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.dhsc.htbhf.claimant.entity.Claimant;
 import uk.gov.dhsc.htbhf.claimant.exception.EligibilityClientException;
-import uk.gov.dhsc.htbhf.dwp.model.v2.IdentityAndEligibilityResponse;
 import uk.gov.dhsc.htbhf.dwp.model.v2.PersonDTOV2;
+import uk.gov.dhsc.htbhf.eligibility.model.CombinedIdentityAndEligibilityResponse;
 
 /**
  * Client for calling V2 of the Eligibility Service using the RestTemplate defined in
@@ -30,14 +30,14 @@ public class EligibilityClientV3 {
         this.restTemplate = restTemplate;
     }
 
-    public IdentityAndEligibilityResponse checkIdentityAndEligibility(Claimant claimant) {
+    public CombinedIdentityAndEligibilityResponse checkIdentityAndEligibility(Claimant claimant) {
         log.debug("Checking V2 eligibility");
         PersonDTOV2 person = buildPersonDTOV2(claimant);
         try {
-            ResponseEntity<IdentityAndEligibilityResponse> response = restTemplate.postForEntity(
+            ResponseEntity<CombinedIdentityAndEligibilityResponse> response = restTemplate.postForEntity(
                     eligibilityUri,
                     person,
-                    IdentityAndEligibilityResponse.class
+                    CombinedIdentityAndEligibilityResponse.class
             );
 
             if (HttpStatus.OK != response.getStatusCode()) {

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/communications/EmailMessagePayloadFactoryTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/communications/EmailMessagePayloadFactoryTest.java
@@ -7,6 +7,7 @@ import uk.gov.dhsc.htbhf.claimant.entity.Claimant;
 import uk.gov.dhsc.htbhf.claimant.entity.PaymentCycle;
 import uk.gov.dhsc.htbhf.claimant.message.payload.EmailMessagePayload;
 import uk.gov.dhsc.htbhf.claimant.message.payload.EmailType;
+import uk.gov.dhsc.htbhf.eligibility.model.testhelper.CombinedIdentityAndEligibilityResponseTestDataFactory;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -26,10 +27,12 @@ import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimTestDataFactory.aClaim
 import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimTestDataFactory.aClaimWithExpectedDeliveryDateAndChildrenDobs;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimTestDataFactory.aValidClaim;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimantTestDataFactory.aValidClaimant;
-import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.*;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aPaymentCycleWithCycleEntitlementAndClaim;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aPaymentCycleWithPregnancyVouchersOnly;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aPaymentCycleWithStartAndEndDate;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory.aValidPaymentCycleBuilder;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementMatchingChildren;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementWithBackdatedVouchersForYoungestChild;
-import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches;
 
 class EmailMessagePayloadFactoryTest {
 
@@ -122,7 +125,8 @@ class EmailMessagePayloadFactoryTest {
         PaymentCycle paymentCycle = aValidPaymentCycleBuilder()
                 .claim(claim)
                 .childrenDob(claim.getClaimant().getChildrenDob())
-                .identityAndEligibilityResponse(anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(claim.getClaimant().getChildrenDob()))
+                .identityAndEligibilityResponse(CombinedIdentityAndEligibilityResponseTestDataFactory
+                        .anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(claim.getClaimant().getChildrenDob()))
                 .voucherEntitlement(aPaymentCycleVoucherEntitlementMatchingChildren(LocalDate.now(), claim.getClaimant().getChildrenDob()))
                 .build();
 

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/creator/ClaimantLoader.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/creator/ClaimantLoader.java
@@ -21,6 +21,7 @@ import uk.gov.dhsc.htbhf.claimant.repository.ClaimRepository;
 import uk.gov.dhsc.htbhf.claimant.repository.PaymentCycleRepository;
 import uk.gov.dhsc.htbhf.claimant.repository.PaymentRepository;
 import uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus;
+import uk.gov.dhsc.htbhf.eligibility.model.testhelper.CombinedIdentityAndEligibilityResponseTestDataFactory;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -34,7 +35,6 @@ import javax.transaction.Transactional;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementMatchingChildrenAndPregnancy;
-import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches;
 
 /**
  * Populates the claimant and DWP database with the data in a {@link ClaimantInfo} object.
@@ -140,10 +140,10 @@ public class ClaimantLoader {
 
     private PaymentCycle createPaymentCycleEndingYesterday(Claim claim, List<ChildInfo> childrenAgeInfo) {
         LocalDate cycleStartDate = LocalDate.now().minusDays(28);
-        List<LocalDate> childrenDatesOfBirth = createListOfChildrenDatesOfBirth(childrenAgeInfo);
+        List<LocalDate> childrenDobs = createListOfChildrenDatesOfBirth(childrenAgeInfo);
         PaymentCycleVoucherEntitlement voucherEntitlement = aPaymentCycleVoucherEntitlementMatchingChildrenAndPregnancy(
                 cycleStartDate,
-                childrenDatesOfBirth,
+                childrenDobs,
                 claim.getClaimant().getExpectedDeliveryDate());
         PaymentCycle paymentCycle = PaymentCycle.builder()
                 .cycleStartDate(cycleStartDate)
@@ -153,8 +153,8 @@ public class ClaimantLoader {
                 .voucherEntitlement(voucherEntitlement)
                 .eligibilityStatus(EligibilityStatus.ELIGIBLE)
                 .identityAndEligibilityResponse(
-                        anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(childrenDatesOfBirth))
-                .childrenDob(childrenDatesOfBirth)
+                        CombinedIdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(childrenDobs))
+                .childrenDob(childrenDobs)
                 .build();
         return paymentCycleRepository.save(paymentCycle);
     }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/EligibilityAndEntitlementDecisionFactoryTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/EligibilityAndEntitlementDecisionFactoryTest.java
@@ -3,64 +3,28 @@ package uk.gov.dhsc.htbhf.claimant.service;
 import org.junit.jupiter.api.Test;
 import uk.gov.dhsc.htbhf.claimant.entitlement.PaymentCycleVoucherEntitlement;
 import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityAndEntitlementDecision;
-import uk.gov.dhsc.htbhf.dwp.model.v2.IdentityAndEligibilityResponse;
+import uk.gov.dhsc.htbhf.eligibility.model.CombinedIdentityAndEligibilityResponse;
 import uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus;
+import uk.gov.dhsc.htbhf.eligibility.model.testhelper.CombinedIdentityAndEligibilityResponseTestDataFactory;
 
 import java.util.UUID;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.dhsc.htbhf.TestConstants.HMRC_HOUSEHOLD_IDENTIFIER;
 import static uk.gov.dhsc.htbhf.TestConstants.NO_HOUSEHOLD_IDENTIFIER_PROVIDED;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.EligibilityAndEntitlementTestDataFactory.aValidDecisionBuilder;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementWithVouchers;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementWithZeroVouchers;
-import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory.anAllMatchedEligibilityConfirmedUCResponseWithHouseholdIdentifier;
-import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityNotConfirmedResponse;
 
 class EligibilityAndEntitlementDecisionFactoryTest {
 
     private static final boolean NOT_DUPLICATE = false;
     private static final boolean DUPLICATE = true;
     private EligibilityAndEntitlementDecisionFactory factory = new EligibilityAndEntitlementDecisionFactory();
-    private IdentityAndEligibilityResponse eligibilityResponse = anAllMatchedEligibilityConfirmedUCResponseWithHouseholdIdentifier();
+    private static final CombinedIdentityAndEligibilityResponse ELIGIBILITY_RESPONSE = CombinedIdentityAndEligibilityResponseTestDataFactory
+            .anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches();
     private static final UUID EXISTING_CLAIM_UUID = UUID.randomUUID();
-
-    @Test
-    void shouldBuildDecisionWithNoHmrcHouseholdIdentifier() {
-        //Given
-        PaymentCycleVoucherEntitlement entitlement = aPaymentCycleVoucherEntitlementWithVouchers();
-
-        //When
-        EligibilityAndEntitlementDecision eligibilityAndEntitlementDecision = factory.buildDecision(eligibilityResponse, entitlement, EXISTING_CLAIM_UUID,
-                null, NOT_DUPLICATE);
-
-        //Then
-        EligibilityAndEntitlementDecision expectedDecision = aValidDecisionBuilder()
-                .identityAndEligibilityResponse(eligibilityResponse)
-                .existingClaimId(EXISTING_CLAIM_UUID)
-                .hmrcHouseholdIdentifier(null)
-                .build();
-        assertThat(eligibilityAndEntitlementDecision).isEqualTo(expectedDecision);
-    }
-
-    @Test
-    void shouldBuildDecisionWithHmrcHouseholdIdentifier() {
-        //Given
-        PaymentCycleVoucherEntitlement entitlement = aPaymentCycleVoucherEntitlementWithVouchers();
-
-        //When
-        EligibilityAndEntitlementDecision eligibilityAndEntitlementDecision = factory.buildDecision(eligibilityResponse, entitlement, EXISTING_CLAIM_UUID,
-                HMRC_HOUSEHOLD_IDENTIFIER, NOT_DUPLICATE);
-
-        //Then
-        EligibilityAndEntitlementDecision expectedDecision = aValidDecisionBuilder()
-                .identityAndEligibilityResponse(eligibilityResponse)
-                .existingClaimId(EXISTING_CLAIM_UUID)
-                .hmrcHouseholdIdentifier(HMRC_HOUSEHOLD_IDENTIFIER)
-                .build();
-        assertThat(eligibilityAndEntitlementDecision).isEqualTo(expectedDecision);
-    }
+    private static final UUID NO_EXISTING_CLAIM_UUID = null;
 
     @Test
     void shouldBuildDecisionWithoutExistingClaimUUID() {
@@ -68,13 +32,12 @@ class EligibilityAndEntitlementDecisionFactoryTest {
         PaymentCycleVoucherEntitlement entitlement = aPaymentCycleVoucherEntitlementWithVouchers();
 
         //When
-        EligibilityAndEntitlementDecision eligibilityAndEntitlementDecision = factory.buildDecision(eligibilityResponse,
-                entitlement, null, null, NOT_DUPLICATE);
+        EligibilityAndEntitlementDecision eligibilityAndEntitlementDecision = factory.buildDecision(ELIGIBILITY_RESPONSE,
+                entitlement, NO_EXISTING_CLAIM_UUID, NOT_DUPLICATE);
 
         //Then
         EligibilityAndEntitlementDecision expectedDecision = aValidDecisionBuilder()
-                .identityAndEligibilityResponse(eligibilityResponse)
-                .hmrcHouseholdIdentifier(null)
+                .identityAndEligibilityResponse(ELIGIBILITY_RESPONSE)
                 .build();
         assertThat(eligibilityAndEntitlementDecision).isEqualTo(expectedDecision);
     }
@@ -85,13 +48,12 @@ class EligibilityAndEntitlementDecisionFactoryTest {
         PaymentCycleVoucherEntitlement entitlement = aPaymentCycleVoucherEntitlementWithVouchers();
 
         //When
-        EligibilityAndEntitlementDecision eligibilityAndEntitlementDecision = factory.buildDecision(eligibilityResponse,
-                entitlement, null, null, DUPLICATE);
+        EligibilityAndEntitlementDecision eligibilityAndEntitlementDecision = factory.buildDecision(ELIGIBILITY_RESPONSE,
+                entitlement, NO_EXISTING_CLAIM_UUID, DUPLICATE);
 
         //Then
         EligibilityAndEntitlementDecision expectedDecision = aValidDecisionBuilder()
-                .identityAndEligibilityResponse(eligibilityResponse)
-                .hmrcHouseholdIdentifier(null)
+                .identityAndEligibilityResponse(ELIGIBILITY_RESPONSE)
                 .voucherEntitlement(null)
                 .eligibilityStatus(EligibilityStatus.DUPLICATE)
                 .build();
@@ -104,14 +66,13 @@ class EligibilityAndEntitlementDecisionFactoryTest {
         PaymentCycleVoucherEntitlement entitlement = aPaymentCycleVoucherEntitlementWithZeroVouchers();
 
         //When
-        EligibilityAndEntitlementDecision eligibilityAndEntitlementDecision = factory.buildDecision(eligibilityResponse,
-                entitlement, EXISTING_CLAIM_UUID, null, NOT_DUPLICATE);
+        EligibilityAndEntitlementDecision eligibilityAndEntitlementDecision = factory.buildDecision(ELIGIBILITY_RESPONSE,
+                entitlement, EXISTING_CLAIM_UUID, NOT_DUPLICATE);
 
         //Then
         EligibilityAndEntitlementDecision expectedDecision = aValidDecisionBuilder()
                 .eligibilityStatus(EligibilityStatus.INELIGIBLE)
-                .identityAndEligibilityResponse(eligibilityResponse)
-                .hmrcHouseholdIdentifier(null)
+                .identityAndEligibilityResponse(ELIGIBILITY_RESPONSE)
                 .voucherEntitlement(null)
                 .existingClaimId(EXISTING_CLAIM_UUID)
                 .build();
@@ -121,19 +82,20 @@ class EligibilityAndEntitlementDecisionFactoryTest {
     @Test
     void shouldBuildDecisionForIneligibleResponse() {
         //Given
-        IdentityAndEligibilityResponse identityAndEligibilityResponse = anIdentityMatchedEligibilityNotConfirmedResponse();
+        CombinedIdentityAndEligibilityResponse identityAndEligibilityResponse = CombinedIdentityAndEligibilityResponseTestDataFactory
+                .anIdentityMatchedEligibilityNotConfirmedResponse();
         PaymentCycleVoucherEntitlement entitlement = aPaymentCycleVoucherEntitlementWithZeroVouchers();
 
         //When
         EligibilityAndEntitlementDecision eligibilityAndEntitlementDecision = factory.buildDecision(identityAndEligibilityResponse, entitlement,
-                EXISTING_CLAIM_UUID, null, NOT_DUPLICATE);
+                EXISTING_CLAIM_UUID, NOT_DUPLICATE);
 
         //Then
         EligibilityAndEntitlementDecision expectedDecision = aValidDecisionBuilder()
                 .eligibilityStatus(EligibilityStatus.INELIGIBLE)
                 .identityAndEligibilityResponse(identityAndEligibilityResponse)
                 .dwpHouseholdIdentifier(NO_HOUSEHOLD_IDENTIFIER_PROVIDED)
-                .hmrcHouseholdIdentifier(null)
+                .hmrcHouseholdIdentifier(NO_HOUSEHOLD_IDENTIFIER_PROVIDED)
                 .voucherEntitlement(null)
                 .dateOfBirthOfChildren(emptyList())
                 .existingClaimId(EXISTING_CLAIM_UUID)

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/claim/ClaimServiceTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/claim/ClaimServiceTest.java
@@ -24,6 +24,7 @@ import uk.gov.dhsc.htbhf.claimant.service.EligibilityAndEntitlementService;
 import uk.gov.dhsc.htbhf.claimant.service.audit.ClaimEventType;
 import uk.gov.dhsc.htbhf.claimant.service.audit.EventAuditor;
 import uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus;
+import uk.gov.dhsc.htbhf.eligibility.model.testhelper.CombinedIdentityAndEligibilityResponseTestDataFactory;
 import uk.gov.dhsc.htbhf.logging.event.CommonEventType;
 import uk.gov.dhsc.htbhf.logging.event.FailureEvent;
 
@@ -59,7 +60,6 @@ import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.EXPECTED_DELI
 import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.TEST_EXCEPTION;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.VerificationResultTestDataFactory.anAllMatchedVerificationResult;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.VoucherEntitlementTestDataFactory.aVoucherEntitlementWithEntitlementDate;
-import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches;
 import static uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus.ELIGIBLE;
 import static uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus.INELIGIBLE;
 
@@ -311,7 +311,8 @@ class ClaimServiceTest {
                 .eligibilityStatus(ELIGIBLE)
                 .existingClaimId(existingClaimId)
                 .voucherEntitlement(aPaymentCycleVoucherEntitlementWithVouchers())
-                .identityAndEligibilityResponse(anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches())
+                .identityAndEligibilityResponse(
+                        CombinedIdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches())
                 .build());
         given(claimRepository.findClaim(any())).willReturn(existingClaim);
         ClaimRequest request = aClaimRequestForClaimant(newClaimant);
@@ -523,7 +524,8 @@ class ClaimServiceTest {
 
     private EligibilityAndEntitlementDecision buildEligibilityAndEntitlementDecision(EligibilityStatus eligibilityStatus, UUID existingClaimId) {
         return aDecisionWithStatusAndExistingClaim(eligibilityStatus, existingClaimId).toBuilder()
-                .identityAndEligibilityResponse(anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches())
+                .identityAndEligibilityResponse(
+                        CombinedIdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches())
                 .build();
     }
 

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/payments/PaymentCycleServiceTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/payments/PaymentCycleServiceTest.java
@@ -14,7 +14,8 @@ import uk.gov.dhsc.htbhf.claimant.model.ClaimStatus;
 import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityAndEntitlementDecision;
 import uk.gov.dhsc.htbhf.claimant.repository.PaymentCycleRepository;
 import uk.gov.dhsc.htbhf.claimant.testsupport.EligibilityAndEntitlementTestDataFactory;
-import uk.gov.dhsc.htbhf.dwp.model.v2.IdentityAndEligibilityResponse;
+import uk.gov.dhsc.htbhf.eligibility.model.CombinedIdentityAndEligibilityResponse;
+import uk.gov.dhsc.htbhf.eligibility.model.testhelper.CombinedIdentityAndEligibilityResponseTestDataFactory;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -38,7 +39,6 @@ import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlem
 import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.EXPECTED_DELIVERY_DATE_TOO_FAR_IN_PAST;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.NOT_PREGNANT;
-import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches;
 import static uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus.ELIGIBLE;
 import static uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus.INELIGIBLE;
 
@@ -84,7 +84,8 @@ class PaymentCycleServiceTest {
         Claim claim = aClaimWithExpectedDeliveryDate(dueDate);
         List<LocalDate> datesOfBirth = List.of(LocalDate.now(), LocalDate.now().minusDays(2));
         PaymentCycleVoucherEntitlement entitlement = aPaymentCycleVoucherEntitlementWithPregnancyVouchers();
-        IdentityAndEligibilityResponse identityAndEligibilityResponse = anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(datesOfBirth);
+        CombinedIdentityAndEligibilityResponse identityAndEligibilityResponse =
+                CombinedIdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(datesOfBirth);
         EligibilityAndEntitlementDecision decision = EligibilityAndEntitlementTestDataFactory.aValidDecisionBuilder()
                 .existingClaimId(claim.getId())
                 .voucherEntitlement(entitlement)
@@ -115,11 +116,14 @@ class PaymentCycleServiceTest {
         Claim claim = aClaimWithExpectedDeliveryDate(expectedDeliveryDate);
         List<LocalDate> datesOfBirth = List.of(LocalDate.now(), LocalDate.now().minusDays(2));
         PaymentCycleVoucherEntitlement entitlement = aPaymentCycleVoucherEntitlementWithoutPregnancyVouchers();
+        CombinedIdentityAndEligibilityResponse identityAndEligibilityResponse = CombinedIdentityAndEligibilityResponseTestDataFactory
+                .anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(datesOfBirth);
         EligibilityAndEntitlementDecision decision = EligibilityAndEntitlementTestDataFactory.aValidDecisionBuilder()
                 .existingClaimId(claim.getId())
                 .voucherEntitlement(entitlement)
                 .dateOfBirthOfChildren(datesOfBirth)
-                .identityAndEligibilityResponse(anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(datesOfBirth))
+                .identityAndEligibilityResponse(
+                        identityAndEligibilityResponse)
                 .build();
         given(pregnancyEntitlementCalculator.isEntitledToVoucher(any(), any())).willReturn(false);
 
@@ -128,7 +132,7 @@ class PaymentCycleServiceTest {
         verifyPaymentCycleSavedCorrectly(claim, result);
         assertThat(result.getVoucherEntitlement()).isEqualTo(entitlement);
         assertThat(result.getEligibilityStatus()).isEqualTo(ELIGIBLE);
-        assertThat(result.getIdentityAndEligibilityResponse()).isEqualTo(anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(datesOfBirth));
+        assertThat(result.getIdentityAndEligibilityResponse()).isEqualTo(identityAndEligibilityResponse);
         assertThat(result.getPaymentCycleStatus()).isEqualTo(NEW);
         assertThat(result.getChildrenDob()).isEqualTo(datesOfBirth);
         assertThat(result.getExpectedDeliveryDate()).isNull();
@@ -220,7 +224,8 @@ class PaymentCycleServiceTest {
         return EligibilityAndEntitlementDecision.builder()
                 .dateOfBirthOfChildren(dateOfBirthOfChildren)
                 .eligibilityStatus(INELIGIBLE)
-                .identityAndEligibilityResponse(anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(dateOfBirthOfChildren))
+                .identityAndEligibilityResponse(CombinedIdentityAndEligibilityResponseTestDataFactory
+                        .anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(dateOfBirthOfChildren))
                 .voucherEntitlement(voucherEntitlement)
                 .build();
     }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/v2/CombinedIdentityAndEligibilityResponseFactoryTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/v2/CombinedIdentityAndEligibilityResponseFactoryTest.java
@@ -5,24 +5,22 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import uk.gov.dhsc.htbhf.claimant.model.eligibility.ChildDTO;
 import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityResponse;
-import uk.gov.dhsc.htbhf.dwp.model.v2.IdentityAndEligibilityResponse;
+import uk.gov.dhsc.htbhf.eligibility.model.CombinedIdentityAndEligibilityResponse;
 import uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.dhsc.htbhf.TestConstants.DWP_HOUSEHOLD_IDENTIFIER;
-import static uk.gov.dhsc.htbhf.claimant.service.v2.IdentityAndEligibilityResponseFactory.fromEligibilityResponse;
+import static uk.gov.dhsc.htbhf.claimant.service.v2.CombinedIdentityAndEligibilityResponseFactory.fromEligibilityResponse;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.EligibilityResponseTestDataFactory.anEligibilityResponseWithChildrenAndStatus;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.EligibilityResponseTestDataFactory.anEligibilityResponseWithStatus;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.EligibilityResponseTestDataFactory.childrenWithBirthdates;
 import static uk.gov.dhsc.htbhf.dwp.testhelper.TestConstants.TWO_CHILDREN;
-import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory.addHouseholdIdentifier;
-import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory.anAllMatchedEligibilityConfirmedUCResponseWithHouseholdIdentifier;
-import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory.anIdentityMatchFailedResponse;
-import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityNotConfirmedResponse;
+import static uk.gov.dhsc.htbhf.eligibility.model.testhelper.CombinedIdentityAndEligibilityResponseTestDataFactory.anIdentityMatchFailedResponse;
+import static uk.gov.dhsc.htbhf.eligibility.model.testhelper.CombinedIdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches;
+import static uk.gov.dhsc.htbhf.eligibility.model.testhelper.CombinedIdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityNotConfirmedResponse;
 
-class IdentityAndEligibilityResponseFactoryTest {
+class CombinedIdentityAndEligibilityResponseFactoryTest {
 
     @Test
     void shouldBuildMatchedResponseFromEligibilityResponse() {
@@ -30,10 +28,9 @@ class IdentityAndEligibilityResponseFactoryTest {
         List<ChildDTO> children = childrenWithBirthdates(TWO_CHILDREN);
         EligibilityResponse eligibilityResponse = anEligibilityResponseWithChildrenAndStatus(children, EligibilityStatus.ELIGIBLE);
         //When
-        IdentityAndEligibilityResponse identityAndEligibilityResponse = fromEligibilityResponse(eligibilityResponse);
+        CombinedIdentityAndEligibilityResponse identityAndEligibilityResponse = fromEligibilityResponse(eligibilityResponse);
         //Then
-        IdentityAndEligibilityResponse expectedResponse = anAllMatchedEligibilityConfirmedUCResponseWithHouseholdIdentifier(TWO_CHILDREN,
-                DWP_HOUSEHOLD_IDENTIFIER);
+        CombinedIdentityAndEligibilityResponse expectedResponse = anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(TWO_CHILDREN);
         assertThat(identityAndEligibilityResponse).isEqualTo(expectedResponse);
     }
 
@@ -42,9 +39,9 @@ class IdentityAndEligibilityResponseFactoryTest {
         //Given
         EligibilityResponse eligibilityResponse = anEligibilityResponseWithStatus(EligibilityStatus.INELIGIBLE);
         //When
-        IdentityAndEligibilityResponse identityAndEligibilityResponse = fromEligibilityResponse(eligibilityResponse);
+        CombinedIdentityAndEligibilityResponse identityAndEligibilityResponse = fromEligibilityResponse(eligibilityResponse);
         //Then
-        IdentityAndEligibilityResponse expectedResponse = addHouseholdIdentifier(anIdentityMatchedEligibilityNotConfirmedResponse(), DWP_HOUSEHOLD_IDENTIFIER);
+        CombinedIdentityAndEligibilityResponse expectedResponse = anIdentityMatchedEligibilityNotConfirmedResponse();
         assertThat(identityAndEligibilityResponse).isEqualTo(expectedResponse);
     }
 
@@ -54,9 +51,9 @@ class IdentityAndEligibilityResponseFactoryTest {
         //Given
         EligibilityResponse eligibilityResponse = anEligibilityResponseWithStatus(eligibilityStatus);
         //When
-        IdentityAndEligibilityResponse identityAndEligibilityResponse = fromEligibilityResponse(eligibilityResponse);
+        CombinedIdentityAndEligibilityResponse identityAndEligibilityResponse = fromEligibilityResponse(eligibilityResponse);
         //Then
-        IdentityAndEligibilityResponse expectedResponse = addHouseholdIdentifier(anIdentityMatchFailedResponse(), DWP_HOUSEHOLD_IDENTIFIER);
+        CombinedIdentityAndEligibilityResponse expectedResponse = anIdentityMatchFailedResponse();
         assertThat(identityAndEligibilityResponse).isEqualTo(expectedResponse);
     }
 

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/v2/EligibilityAndEntitlementServiceV2Test.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/v2/EligibilityAndEntitlementServiceV2Test.java
@@ -15,8 +15,9 @@ import uk.gov.dhsc.htbhf.claimant.repository.ClaimRepository;
 import uk.gov.dhsc.htbhf.claimant.service.DuplicateClaimChecker;
 import uk.gov.dhsc.htbhf.claimant.service.EligibilityAndEntitlementDecisionFactory;
 import uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleTestDataFactory;
-import uk.gov.dhsc.htbhf.dwp.model.v2.IdentityAndEligibilityResponse;
+import uk.gov.dhsc.htbhf.eligibility.model.CombinedIdentityAndEligibilityResponse;
 import uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus;
+import uk.gov.dhsc.htbhf.eligibility.model.testhelper.CombinedIdentityAndEligibilityResponseTestDataFactory;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -29,17 +30,12 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static uk.gov.dhsc.htbhf.TestConstants.DWP_HOUSEHOLD_IDENTIFIER;
-import static uk.gov.dhsc.htbhf.TestConstants.HMRC_HOUSEHOLD_IDENTIFIER;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimantTestDataFactory.aValidClaimant;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.EligibilityAndEntitlementTestDataFactory.aDecisionWithStatus;
-import static uk.gov.dhsc.htbhf.claimant.testsupport.EligibilityResponseTestDataFactory.anEligibilityResponseWithDwpHouseholdIdentifier;
-import static uk.gov.dhsc.htbhf.claimant.testsupport.EligibilityResponseTestDataFactory.anEligibilityResponseWithHmrcHouseholdIdentifier;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.EligibilityResponseTestDataFactory.anEligibilityResponseWithStatus;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementWithVouchers;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS;
 import static uk.gov.dhsc.htbhf.dwp.testhelper.TestConstants.HOMER_NINO_V1;
-import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory.anAllMatchedEligibilityConfirmedUCResponseWithHouseholdIdentifier;
 import static uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus.ELIGIBLE;
 import static uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus.INELIGIBLE;
 
@@ -50,6 +46,8 @@ class EligibilityAndEntitlementServiceV2Test {
     private static final boolean DUPLICATE = true;
     private static final EligibilityResponse ELIGIBILITY_RESPONSE = anEligibilityResponseWithStatus(ELIGIBLE);
     private static final List<LocalDate> DATE_OF_BIRTH_OF_CHILDREN = ELIGIBILITY_RESPONSE.getDateOfBirthOfChildren();
+    private static final CombinedIdentityAndEligibilityResponse COMBINED_ELIGIBILITY_RESPONSE = CombinedIdentityAndEligibilityResponseTestDataFactory
+            .anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(DATE_OF_BIRTH_OF_CHILDREN);
     private static final PaymentCycleVoucherEntitlement VOUCHER_ENTITLEMENT = aPaymentCycleVoucherEntitlementWithVouchers();
     private static final Claimant CLAIMANT = aValidClaimant();
 
@@ -84,14 +82,14 @@ class EligibilityAndEntitlementServiceV2Test {
         //Then
         assertThat(decision).isEqualTo(decisionResponse);
         verifyCommonMocks();
-        verifyDecisionFactoryCalledCorrectly(existingClaimId, NOT_DUPLICATE, HMRC_HOUSEHOLD_IDENTIFIER, DWP_HOUSEHOLD_IDENTIFIER);
+        verify(eligibilityAndEntitlementDecisionFactory).buildDecision(COMBINED_ELIGIBILITY_RESPONSE, VOUCHER_ENTITLEMENT, existingClaimId, NOT_DUPLICATE);
         verifyNoInteractions(duplicateClaimChecker);
     }
 
     @Test
     void shouldReturnEligibleWhenNotDuplicateAndEligible() {
         //Given
-        setupCommonMocksWithoutClaimId();
+        setupCommonMocks(null);
         given(duplicateClaimChecker.liveClaimExistsForHousehold(any(EligibilityResponse.class))).willReturn(false);
         EligibilityAndEntitlementDecision decisionResponse = setupEligibilityAndEntitlementDecisionFactory(ELIGIBLE);
 
@@ -102,49 +100,13 @@ class EligibilityAndEntitlementServiceV2Test {
         assertThat(result).isEqualTo(decisionResponse);
         verifyCommonMocks();
         verify(duplicateClaimChecker).liveClaimExistsForHousehold(ELIGIBILITY_RESPONSE);
-        verifyDecisionFactoryCalledCorrectly(null, NOT_DUPLICATE, HMRC_HOUSEHOLD_IDENTIFIER, DWP_HOUSEHOLD_IDENTIFIER);
-    }
-
-    @Test
-    void shouldReturnSuccessfullyWithoutHmrcHouseholdIdentifier() {
-        //Given
-        EligibilityResponse eligibilityResponse = anEligibilityResponseWithHmrcHouseholdIdentifier(null);
-        setupCommonMocks(eligibilityResponse);
-        given(duplicateClaimChecker.liveClaimExistsForHousehold(any(EligibilityResponse.class))).willReturn(false);
-        EligibilityAndEntitlementDecision decisionResponse = setupEligibilityAndEntitlementDecisionFactory(ELIGIBLE);
-
-        //When
-        EligibilityAndEntitlementDecision result = eligibilityAndEntitlementServiceV2.evaluateNewClaimant(CLAIMANT);
-
-        //Then
-        assertThat(result).isEqualTo(decisionResponse);
-        verifyCommonMocks();
-        verify(duplicateClaimChecker).liveClaimExistsForHousehold(eligibilityResponse);
-        verifyDecisionFactoryCalledCorrectly(null, NOT_DUPLICATE, null, DWP_HOUSEHOLD_IDENTIFIER);
-    }
-
-    @Test
-    void shouldReturnSuccessfullyWithoutDwpHouseholdIdentifier() {
-        //Given
-        EligibilityResponse eligibilityResponse = anEligibilityResponseWithDwpHouseholdIdentifier(null);
-        setupCommonMocks(eligibilityResponse);
-        given(duplicateClaimChecker.liveClaimExistsForHousehold(any(EligibilityResponse.class))).willReturn(false);
-        EligibilityAndEntitlementDecision decisionResponse = setupEligibilityAndEntitlementDecisionFactory(ELIGIBLE);
-
-        //When
-        EligibilityAndEntitlementDecision result = eligibilityAndEntitlementServiceV2.evaluateNewClaimant(CLAIMANT);
-
-        //Then
-        assertThat(result).isEqualTo(decisionResponse);
-        verifyCommonMocks();
-        verify(duplicateClaimChecker).liveClaimExistsForHousehold(eligibilityResponse);
-        verifyDecisionFactoryCalledCorrectly(null, NOT_DUPLICATE, HMRC_HOUSEHOLD_IDENTIFIER, null);
+        verify(eligibilityAndEntitlementDecisionFactory).buildDecision(COMBINED_ELIGIBILITY_RESPONSE, VOUCHER_ENTITLEMENT, null, NOT_DUPLICATE);
     }
 
     @Test
     void shouldReturnDuplicateForExistingHousehold() {
         //Given
-        setupCommonMocksWithoutClaimId();
+        setupCommonMocks(null);
         given(duplicateClaimChecker.liveClaimExistsForHousehold(ELIGIBILITY_RESPONSE)).willReturn(DUPLICATE);
         EligibilityAndEntitlementDecision decisionResponse = setupEligibilityAndEntitlementDecisionFactory(EligibilityStatus.DUPLICATE);
 
@@ -155,7 +117,7 @@ class EligibilityAndEntitlementServiceV2Test {
         assertThat(result).isEqualTo(decisionResponse);
         verifyCommonMocks();
         verify(duplicateClaimChecker).liveClaimExistsForHousehold(ELIGIBILITY_RESPONSE);
-        verifyDecisionFactoryCalledCorrectly(null, DUPLICATE, HMRC_HOUSEHOLD_IDENTIFIER, DWP_HOUSEHOLD_IDENTIFIER);
+        verify(eligibilityAndEntitlementDecisionFactory).buildDecision(COMBINED_ELIGIBILITY_RESPONSE, VOUCHER_ENTITLEMENT, null, DUPLICATE);
     }
 
     @Test
@@ -178,40 +140,20 @@ class EligibilityAndEntitlementServiceV2Test {
                 DATE_OF_BIRTH_OF_CHILDREN,
                 cycleStartDate,
                 previousCycle.getVoucherEntitlement());
-        verifyDecisionFactoryCalledCorrectly(null, NOT_DUPLICATE, HMRC_HOUSEHOLD_IDENTIFIER, DWP_HOUSEHOLD_IDENTIFIER);
+        verify(eligibilityAndEntitlementDecisionFactory).buildDecision(COMBINED_ELIGIBILITY_RESPONSE, VOUCHER_ENTITLEMENT, null, NOT_DUPLICATE);
         verifyNoInteractions(duplicateClaimChecker, claimRepository);
     }
 
     private EligibilityAndEntitlementDecision setupEligibilityAndEntitlementDecisionFactory(EligibilityStatus status) {
         EligibilityAndEntitlementDecision decisionResponse = aDecisionWithStatus(status);
-        given(eligibilityAndEntitlementDecisionFactory.buildDecision(any(), any(), any(), any(), anyBoolean())).willReturn(decisionResponse);
+        given(eligibilityAndEntitlementDecisionFactory.buildDecision(any(), any(), any(), anyBoolean())).willReturn(decisionResponse);
         return decisionResponse;
     }
 
-    private void setupCommonMocksWithoutClaimId() {
-        setupCommonMocks(ELIGIBILITY_RESPONSE, null);
-    }
-
     private void setupCommonMocks(UUID existingClaimId) {
-        setupCommonMocks(ELIGIBILITY_RESPONSE, existingClaimId);
-    }
-
-    private void setupCommonMocks(EligibilityResponse eligibilityResponse) {
-        setupCommonMocks(eligibilityResponse, null);
-    }
-
-    private void setupCommonMocks(EligibilityResponse eligibilityResponse, UUID existingClaimId) {
-        given(client.checkEligibility(any())).willReturn(eligibilityResponse);
+        given(client.checkEligibility(any())).willReturn(ELIGIBILITY_RESPONSE);
         given(paymentCycleEntitlementCalculator.calculateEntitlement(any(), any(), any())).willReturn(VOUCHER_ENTITLEMENT);
         given(claimRepository.findLiveClaimWithNino(any())).willReturn(Optional.ofNullable(existingClaimId));
-    }
-
-    private void verifyDecisionFactoryCalledCorrectly(UUID existingClaimId, boolean duplicate,
-                                                      String hmrcHouseholdIdentifier, String dwpHouseholdIdentifier) {
-        IdentityAndEligibilityResponse expectedIdentityAndEligibilityResponse = anAllMatchedEligibilityConfirmedUCResponseWithHouseholdIdentifier(
-                DATE_OF_BIRTH_OF_CHILDREN, dwpHouseholdIdentifier);
-        verify(eligibilityAndEntitlementDecisionFactory).buildDecision(expectedIdentityAndEligibilityResponse,
-                VOUCHER_ENTITLEMENT, existingClaimId, hmrcHouseholdIdentifier, duplicate);
     }
 
     private void verifyCommonMocks() {

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/v3/EligibilityClientV3Test.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/v3/EligibilityClientV3Test.java
@@ -11,7 +11,7 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.dhsc.htbhf.claimant.entity.Claimant;
 import uk.gov.dhsc.htbhf.claimant.exception.EligibilityClientException;
-import uk.gov.dhsc.htbhf.dwp.model.v2.IdentityAndEligibilityResponse;
+import uk.gov.dhsc.htbhf.eligibility.model.CombinedIdentityAndEligibilityResponse;
 
 import java.time.LocalDate;
 
@@ -24,8 +24,8 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimantTestDataFactory.aClaimantWithNino;
 import static uk.gov.dhsc.htbhf.dwp.testhelper.TestConstants.HOMER_NINO_V2;
-import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches;
 import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.PersonDTOV2TestDataFactory.aPersonDTOV2WithPregnantDependantDob;
+import static uk.gov.dhsc.htbhf.eligibility.model.testhelper.CombinedIdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches;
 
 @ExtendWith(MockitoExtension.class)
 class EligibilityClientV3Test {
@@ -47,23 +47,23 @@ class EligibilityClientV3Test {
     @Test
     void shouldCheckIdentityAndEligibilitySuccessfully() {
         Claimant claimant = aClaimantWithNino(HOMER_NINO_V2);
-        IdentityAndEligibilityResponse identityAndEligibilityResponse = anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches();
-        ResponseEntity<IdentityAndEligibilityResponse> response = new ResponseEntity<>(identityAndEligibilityResponse, HttpStatus.OK);
-        given(restTemplate.postForEntity(anyString(), any(), eq(IdentityAndEligibilityResponse.class)))
+        CombinedIdentityAndEligibilityResponse identityAndEligibilityResponse = anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches();
+        ResponseEntity<CombinedIdentityAndEligibilityResponse> response = new ResponseEntity<>(identityAndEligibilityResponse, HttpStatus.OK);
+        given(restTemplate.postForEntity(anyString(), any(), eq(CombinedIdentityAndEligibilityResponse.class)))
                 .willReturn(response);
 
-        IdentityAndEligibilityResponse actualResponse = client.checkIdentityAndEligibility(claimant);
+        CombinedIdentityAndEligibilityResponse actualResponse = client.checkIdentityAndEligibility(claimant);
 
         assertThat(actualResponse).isEqualTo(identityAndEligibilityResponse);
-        verify(restTemplate).postForEntity(FULL_URI, aPersonDTOV2WithPregnantDependantDob(NO_PREGNANT_DEPENDANT), IdentityAndEligibilityResponse.class);
+        verify(restTemplate).postForEntity(FULL_URI, aPersonDTOV2WithPregnantDependantDob(NO_PREGNANT_DEPENDANT), CombinedIdentityAndEligibilityResponse.class);
     }
 
     @Test
     void shouldThrowAnExceptionWhenPostCallNotOk() {
         Claimant claimant = aClaimantWithNino(HOMER_NINO_V2);
-        IdentityAndEligibilityResponse identityAndEligibilityResponse = anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches();
-        ResponseEntity<IdentityAndEligibilityResponse> response = new ResponseEntity<>(identityAndEligibilityResponse, HttpStatus.BAD_REQUEST);
-        given(restTemplate.postForEntity(anyString(), any(), eq(IdentityAndEligibilityResponse.class)))
+        CombinedIdentityAndEligibilityResponse identityAndEligibilityResponse = anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches();
+        ResponseEntity<CombinedIdentityAndEligibilityResponse> response = new ResponseEntity<>(identityAndEligibilityResponse, HttpStatus.BAD_REQUEST);
+        given(restTemplate.postForEntity(anyString(), any(), eq(CombinedIdentityAndEligibilityResponse.class)))
                 .willReturn(response);
 
         EligibilityClientException thrown = catchThrowableOfType(() -> client.checkIdentityAndEligibility(claimant), EligibilityClientException.class);
@@ -71,14 +71,14 @@ class EligibilityClientV3Test {
         assertThat(thrown).as("Should throw an Exception when response code is not OK")
                 .isNotNull()
                 .hasMessage("Response code from Eligibility service was not OK, received: 400");
-        verify(restTemplate).postForEntity(FULL_URI, aPersonDTOV2WithPregnantDependantDob(NO_PREGNANT_DEPENDANT), IdentityAndEligibilityResponse.class);
+        verify(restTemplate).postForEntity(FULL_URI, aPersonDTOV2WithPregnantDependantDob(NO_PREGNANT_DEPENDANT), CombinedIdentityAndEligibilityResponse.class);
     }
 
     @Test
     void shouldThrowAnExceptionWhenPostCallReturnsError() {
         Claimant claimant = aClaimantWithNino(HOMER_NINO_V2);
         RestClientException testException = new RestClientException("Test exception");
-        given(restTemplate.postForEntity(anyString(), any(), eq(IdentityAndEligibilityResponse.class)))
+        given(restTemplate.postForEntity(anyString(), any(), eq(CombinedIdentityAndEligibilityResponse.class)))
                 .willThrow(testException);
 
         EligibilityClientException thrown = catchThrowableOfType(() -> client.checkIdentityAndEligibility(claimant), EligibilityClientException.class);
@@ -87,7 +87,7 @@ class EligibilityClientV3Test {
                 .isNotNull()
                 .hasMessage("Exception caught trying to call eligibility service at: " + FULL_URI)
                 .hasCause(testException);
-        verify(restTemplate).postForEntity(FULL_URI, aPersonDTOV2WithPregnantDependantDob(NO_PREGNANT_DEPENDANT), IdentityAndEligibilityResponse.class);
+        verify(restTemplate).postForEntity(FULL_URI, aPersonDTOV2WithPregnantDependantDob(NO_PREGNANT_DEPENDANT), CombinedIdentityAndEligibilityResponse.class);
     }
 
 }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/EligibilityAndEntitlementTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/EligibilityAndEntitlementTestDataFactory.java
@@ -2,8 +2,9 @@ package uk.gov.dhsc.htbhf.claimant.testsupport;
 
 import uk.gov.dhsc.htbhf.claimant.model.eligibility.EligibilityAndEntitlementDecision;
 import uk.gov.dhsc.htbhf.dwp.model.v2.EligibilityOutcome;
-import uk.gov.dhsc.htbhf.dwp.model.v2.IdentityAndEligibilityResponse;
+import uk.gov.dhsc.htbhf.eligibility.model.CombinedIdentityAndEligibilityResponse;
 import uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus;
+import uk.gov.dhsc.htbhf.eligibility.model.testhelper.CombinedIdentityAndEligibilityResponseTestDataFactory;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -19,8 +20,6 @@ import static uk.gov.dhsc.htbhf.TestConstants.MAGGIE_DATE_OF_BIRTH;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementWithVouchers;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.NUMBER_OF_CHILDREN_UNDER_FOUR;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.NUMBER_OF_CHILDREN_UNDER_ONE;
-import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches;
-import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityNotConfirmedResponse;
 import static uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus.ELIGIBLE;
 
 public class EligibilityAndEntitlementTestDataFactory {
@@ -37,9 +36,9 @@ public class EligibilityAndEntitlementTestDataFactory {
         EligibilityAndEntitlementDecision.EligibilityAndEntitlementDecisionBuilder builder = aValidDecisionBuilder()
                 .eligibilityStatus(eligibilityStatus)
                 .existingClaimId(existingClaimId);
-        IdentityAndEligibilityResponse identityAndEligibilityResponse = (ELIGIBLE == eligibilityStatus)
-                ? anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches()
-                : anIdentityMatchedEligibilityNotConfirmedResponse();
+        CombinedIdentityAndEligibilityResponse identityAndEligibilityResponse = (ELIGIBLE == eligibilityStatus)
+                ? CombinedIdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches()
+                : CombinedIdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityNotConfirmedResponse();
         removeVoucherEntitlementIfAppropriate(eligibilityStatus, builder);
         builder.identityAndEligibilityResponse(identityAndEligibilityResponse);
         return builder.build();
@@ -50,9 +49,9 @@ public class EligibilityAndEntitlementTestDataFactory {
                                                                                    List<LocalDate> childrenDobs) {
         EligibilityAndEntitlementDecision.EligibilityAndEntitlementDecisionBuilder builder = aValidDecisionBuilder().eligibilityStatus(eligibilityStatus);
         removeVoucherEntitlementIfAppropriate(eligibilityStatus, builder);
-        IdentityAndEligibilityResponse identityAndEligibilityResponse = (EligibilityOutcome.CONFIRMED == eligibilityOutcome)
-                ? anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(childrenDobs)
-                : anIdentityMatchedEligibilityNotConfirmedResponse();
+        CombinedIdentityAndEligibilityResponse identityAndEligibilityResponse = (EligibilityOutcome.CONFIRMED == eligibilityOutcome)
+                ? CombinedIdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(childrenDobs)
+                : CombinedIdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityNotConfirmedResponse();
         return builder
                 .identityAndEligibilityResponse(identityAndEligibilityResponse)
                 .dateOfBirthOfChildren(childrenDobs)
@@ -70,7 +69,8 @@ public class EligibilityAndEntitlementTestDataFactory {
         List<LocalDate> children = createChildren(NUMBER_OF_CHILDREN_UNDER_ONE, NUMBER_OF_CHILDREN_UNDER_FOUR);
         return EligibilityAndEntitlementDecision.builder()
                 .eligibilityStatus(ELIGIBLE)
-                .identityAndEligibilityResponse(anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(children))
+                .identityAndEligibilityResponse(
+                        CombinedIdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(children))
                 .dwpHouseholdIdentifier(DWP_HOUSEHOLD_IDENTIFIER)
                 .hmrcHouseholdIdentifier(HMRC_HOUSEHOLD_IDENTIFIER)
                 .voucherEntitlement(aPaymentCycleVoucherEntitlementWithVouchers())

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/PaymentCycleTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/PaymentCycleTestDataFactory.java
@@ -6,6 +6,7 @@ import uk.gov.dhsc.htbhf.claimant.entity.Payment;
 import uk.gov.dhsc.htbhf.claimant.entity.PaymentCycle;
 import uk.gov.dhsc.htbhf.claimant.entity.PaymentCycleStatus;
 import uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus;
+import uk.gov.dhsc.htbhf.eligibility.model.testhelper.CombinedIdentityAndEligibilityResponseTestDataFactory;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -17,7 +18,6 @@ import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlem
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementWithPregnancyVouchers;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementWithVouchers;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PaymentCycleVoucherEntitlementTestDataFactory.aPaymentCycleVoucherEntitlementWithVouchersFromDate;
-import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches;
 
 public class PaymentCycleTestDataFactory {
 
@@ -37,7 +37,8 @@ public class PaymentCycleTestDataFactory {
                 .claim(claim)
                 .childrenDob(childrenDobs)
                 .expectedDeliveryDate(nullSafeGetExpectedDeliveryDate(claim))
-                .identityAndEligibilityResponse(anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(childrenDobs))
+                .identityAndEligibilityResponse(
+                        CombinedIdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(childrenDobs))
                 .build();
     }
 
@@ -52,7 +53,8 @@ public class PaymentCycleTestDataFactory {
                 .claim(claim)
                 .childrenDob(childrenDobs)
                 .expectedDeliveryDate(nullSafeGetExpectedDeliveryDate(claim))
-                .identityAndEligibilityResponse(anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(childrenDobs))
+                .identityAndEligibilityResponse(
+                        CombinedIdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(childrenDobs))
                 .build();
     }
 
@@ -82,7 +84,8 @@ public class PaymentCycleTestDataFactory {
                 .totalEntitlementAmountInPence(voucherEntitlement.getTotalVoucherValueInPence())
                 .totalVouchers(4)
                 .childrenDob(childrenDobs)
-                .identityAndEligibilityResponse(anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(childrenDobs))
+                .identityAndEligibilityResponse(
+                        CombinedIdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(childrenDobs))
                 .build();
     }
 
@@ -92,7 +95,8 @@ public class PaymentCycleTestDataFactory {
                 .claim(claim)
                 .childrenDob(childrenDobs)
                 .expectedDeliveryDate(nullSafeGetExpectedDeliveryDate(claim))
-                .identityAndEligibilityResponse(anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(childrenDobs))
+                .identityAndEligibilityResponse(
+                        CombinedIdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(childrenDobs))
                 .build();
         paymentCycle.addPayment(payment);
         return paymentCycle;
@@ -104,7 +108,8 @@ public class PaymentCycleTestDataFactory {
                 .claim(claim)
                 .childrenDob(childrenDobs)
                 .expectedDeliveryDate(nullSafeGetExpectedDeliveryDate(claim))
-                .identityAndEligibilityResponse(anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(childrenDobs))
+                .identityAndEligibilityResponse(
+                        CombinedIdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(childrenDobs))
                 .build();
     }
 
@@ -115,7 +120,8 @@ public class PaymentCycleTestDataFactory {
     public static PaymentCycle aPaymentCycleWithChildrenDobs(List<LocalDate> childrenDobs) {
         return aValidPaymentCycleBuilder()
                 .childrenDob(childrenDobs)
-                .identityAndEligibilityResponse(anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(childrenDobs))
+                .identityAndEligibilityResponse(
+                        CombinedIdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(childrenDobs))
                 .build();
     }
 
@@ -123,7 +129,8 @@ public class PaymentCycleTestDataFactory {
         return aValidPaymentCycleBuilder()
                 .claim(claim)
                 .childrenDob(childrenDobs)
-                .identityAndEligibilityResponse(anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(childrenDobs))
+                .identityAndEligibilityResponse(
+                        CombinedIdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(childrenDobs))
                 .build();
     }
 
@@ -152,7 +159,8 @@ public class PaymentCycleTestDataFactory {
                 .childrenDob(childrenDobs)
                 .totalEntitlementAmountInPence(TOTAL_ENTITLEMENT_AMOUNT_IN_PENCE)
                 .expectedDeliveryDate(claim.getClaimant().getExpectedDeliveryDate())
-                .identityAndEligibilityResponse(anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(childrenDobs));
+                .identityAndEligibilityResponse(
+                        CombinedIdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(childrenDobs));
     }
 
     private static List<LocalDate> nullSafeGetChildrenDob(Claim claim) {


### PR DESCRIPTION
…eligibility-service rather than the DWP IdentityAndEligibilityResponse

Sorry for this size of this PR (although net number of lines changed is negative :-) ) but this change had to ripple through the whole of the claimant service.

Some tests needed to be removed because the scenarios they were testing (with/without HMRC household identifier) are no longer applicable because this gets taken directly from the response from the eligibility-service response and there is no difference between v2 and v3 versions in that respect.