### PR TITLE
AFGS-565 Returning a 404 when a claim has not been found.

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/controller/ClaimController.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/controller/ClaimController.java
@@ -66,6 +66,7 @@ public class ClaimController {
 
     @GetMapping("/{id}")
     @ApiOperation("Retrieve a claim by id.")
+    @ApiResponses({@ApiResponse(code = 404, message = "Claim not found", response = ErrorResponse.class)})
     public ClaimDTO retrieveClaimById(@PathVariable("id") UUID id) {
         log.debug("Retrieve claim by id {}", id);
 

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/repository/ClaimRepository.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/repository/ClaimRepository.java
@@ -7,13 +7,13 @@ import org.springframework.data.repository.query.Param;
 import uk.gov.dhsc.htbhf.claimant.entity.CardStatus;
 import uk.gov.dhsc.htbhf.claimant.entity.Claim;
 import uk.gov.dhsc.htbhf.claimant.exception.MultipleClaimsWithSameNinoException;
+import uk.gov.dhsc.htbhf.database.exception.EntityNotFoundException;
 
 import java.time.LocalDateTime;
 import java.time.Period;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import javax.persistence.EntityNotFoundException;
 
 import static uk.gov.dhsc.htbhf.claimant.entity.CardStatus.PENDING_CANCELLATION;
 

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/ClaimantServiceIntegrationTests.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/ClaimantServiceIntegrationTests.java
@@ -27,6 +27,7 @@ import uk.gov.dhsc.htbhf.errorhandler.ErrorResponse;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
@@ -108,6 +109,19 @@ class ClaimantServiceIntegrationTests {
                 "initialIdentityAndEligibilityResponse");
         assertThat(claimResponse.getClaimant()).isEqualToIgnoringGivenFields(claim.getClaimant(), "address");
         assertThat(claimResponse.getClaimant().getAddress()).isEqualToComparingFieldByField(claim.getClaimant().getAddress());
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenClaimWithGivenIdDoesNotExist() {
+        UUID claimId = UUID.randomUUID();
+
+        ResponseEntity<ErrorResponse> response = restTemplate.exchange(buildRetrieveClaimRequestEntity(claimId), ErrorResponse.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(NOT_FOUND);
+        assertThat(response.getBody().getStatus()).isEqualTo(NOT_FOUND.value());
+        assertThat(response.getBody().getMessage()).isEqualTo("Unable to find claim with id " + claimId.toString());
+        assertThat(response.getBody().getTimestamp()).isNotNull();
+        assertThat(response.getBody().getRequestId()).isNotNull();
     }
 
     @Test

--- a/swagger.yml
+++ b/swagger.yml
@@ -77,7 +77,9 @@ paths:
         "403":
           description: "Forbidden"
         "404":
-          description: "Not Found"
+          description: "Claim not found"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
       deprecated: false
 definitions:
   AddressDTO:


### PR DESCRIPTION
Updated claim repository to use custom EntityNotFoundException class which is handled by the common ErrorHandler to return a 404.