### PR TITLE
AFHS-1762 - Null pointer exception bug in ReportPropertiesFactory 

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/reporting/payload/ReportPropertiesFactory.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/reporting/payload/ReportPropertiesFactory.java
@@ -119,10 +119,11 @@ public abstract class ReportPropertiesFactory {
 
     protected Map<String, Object> createCommonCustomMetrics(ReportEventMessageContext context) {
         Map<String, Object> customMetrics = new TreeMap<>();
-        Claimant claimant = context.getClaim().getClaimant();
+        Claim claim = context.getClaim();
+        Claimant claimant = claim.getClaimant();
         LocalDate atDate = context.getTimestamp().toLocalDate();
         customMetrics.put(CLAIMANT_AGE.getFieldName(), Period.between(claimant.getDateOfBirth(), atDate).getYears());
-        List<LocalDate> dobOfChildrenUnder4 = getDobOfChildrenUnder4(context.getClaim(), context.getIdentityAndEligibilityResponse());
+        List<LocalDate> dobOfChildrenUnder4 = getDobOfChildrenUnder4(claim, context.getIdentityAndEligibilityResponse());
         long childrenUnder4 = getNumberOfChildrenUnderFour(dobOfChildrenUnder4, atDate);
         long childrenUnder1 = getNumberOfChildrenUnderOne(dobOfChildrenUnder4, atDate);
         customMetrics.put(CHILDREN_UNDER_ONE.getFieldName(), childrenUnder1);

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/reporting/payload/ReportPropertiesFactory.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/reporting/payload/ReportPropertiesFactory.java
@@ -5,6 +5,8 @@ import uk.gov.dhsc.htbhf.claimant.entity.Claimant;
 import uk.gov.dhsc.htbhf.claimant.message.context.ReportEventMessageContext;
 import uk.gov.dhsc.htbhf.claimant.model.PostcodeData;
 import uk.gov.dhsc.htbhf.claimant.reporting.ClaimantCategoryCalculator;
+import uk.gov.dhsc.htbhf.dwp.model.QualifyingBenefits;
+import uk.gov.dhsc.htbhf.eligibility.model.CombinedIdentityAndEligibilityResponse;
 
 import java.time.Duration;
 import java.time.LocalDate;
@@ -82,7 +84,10 @@ public abstract class ReportPropertiesFactory {
         Map<String, Object> customDimensions = new TreeMap<>();
         customDimensions.put(USER_TYPE.getFieldName(), ONLINE.name());
         Claim claim = context.getClaim();
-        List<LocalDate> dobOfChildrenUnder4 = context.getIdentityAndEligibilityResponse().getDobOfChildrenUnder4();
+
+        CombinedIdentityAndEligibilityResponse identityAndEligibilityResponse = context.getIdentityAndEligibilityResponse();
+        List<LocalDate> dobOfChildrenUnder4 = getDobOfChildrenUnder4(claim, identityAndEligibilityResponse);
+
         ClaimantCategory claimantCategory = claimantCategoryCalculator
                 .determineClaimantCategory(claim.getClaimant(), dobOfChildrenUnder4, context.getTimestamp().toLocalDate());
 
@@ -95,9 +100,21 @@ public abstract class ReportPropertiesFactory {
         customDimensions.put(WESTMINSTER_PARLIAMENTARY_CONSTITUENCY.getFieldName(), postcodeData.getParliamentaryConstituency());
         customDimensions.put(CLINICAL_COMMISSIONING_GROUP.getFieldName(), postcodeData.getCcg());
         customDimensions.put(CLINICAL_COMMISSIONING_GROUP_CODE.getFieldName(), postcodeData.getCodes().getCcg());
-        customDimensions.put(QUALIFYING_BENEFIT.getFieldName(), context.getIdentityAndEligibilityResponse().getQualifyingBenefits());
+        customDimensions.put(QUALIFYING_BENEFIT.getFieldName(), getQualifyingBenefits(identityAndEligibilityResponse));
 
         return customDimensions;
+    }
+
+    private List<LocalDate> getDobOfChildrenUnder4(Claim claim, CombinedIdentityAndEligibilityResponse identityAndEligibilityResponse) {
+        return identityAndEligibilityResponse == null
+                ? claim.getClaimant().getInitiallyDeclaredChildrenDob()
+                : identityAndEligibilityResponse.getDobOfChildrenUnder4();
+    }
+
+    private QualifyingBenefits getQualifyingBenefits(CombinedIdentityAndEligibilityResponse identityAndEligibilityResponse) {
+        return identityAndEligibilityResponse == null
+                ? QualifyingBenefits.NOT_SET
+                : identityAndEligibilityResponse.getQualifyingBenefits();
     }
 
     protected Map<String, Object> createCommonCustomMetrics(ReportEventMessageContext context) {
@@ -105,7 +122,7 @@ public abstract class ReportPropertiesFactory {
         Claimant claimant = context.getClaim().getClaimant();
         LocalDate atDate = context.getTimestamp().toLocalDate();
         customMetrics.put(CLAIMANT_AGE.getFieldName(), Period.between(claimant.getDateOfBirth(), atDate).getYears());
-        List<LocalDate> dobOfChildrenUnder4 = context.getIdentityAndEligibilityResponse().getDobOfChildrenUnder4();
+        List<LocalDate> dobOfChildrenUnder4 = getDobOfChildrenUnder4(context.getClaim(), context.getIdentityAndEligibilityResponse());
         long childrenUnder4 = getNumberOfChildrenUnderFour(dobOfChildrenUnder4, atDate);
         long childrenUnder1 = getNumberOfChildrenUnderOne(dobOfChildrenUnder4, atDate);
         customMetrics.put(CHILDREN_UNDER_ONE.getFieldName(), childrenUnder1);

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/reporting/payload/ReportClaimPropertiesFactoryTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/reporting/payload/ReportClaimPropertiesFactoryTest.java
@@ -11,7 +11,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.dhsc.htbhf.claimant.entity.Claim;
 import uk.gov.dhsc.htbhf.claimant.message.context.ReportClaimMessageContext;
-import uk.gov.dhsc.htbhf.claimant.model.UpdatableClaimantField;
 import uk.gov.dhsc.htbhf.claimant.reporting.ClaimantCategoryCalculator;
 
 import java.time.LocalDate;
@@ -30,13 +29,11 @@ import static org.mockito.Mockito.verify;
 import static uk.gov.dhsc.htbhf.TestConstants.*;
 import static uk.gov.dhsc.htbhf.claimant.model.UpdatableClaimantField.FIRST_NAME;
 import static uk.gov.dhsc.htbhf.claimant.model.UpdatableClaimantField.LAST_NAME;
-import static uk.gov.dhsc.htbhf.claimant.reporting.ClaimAction.NEW;
-import static uk.gov.dhsc.htbhf.claimant.reporting.ClaimAction.UPDATED;
-import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimTestDataFactory.aClaimWithChildrenDobAndDueDateAndPostcodeData;
-import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimTestDataFactory.aClaimWithDueDateAndPostcodeData;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.ReportClaimMessageContextTestDataFactory.aReportClaimMessageContext;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.ReportClaimMessageContextTestDataFactory.aReportClaimMessageContextForAnUpdatedClaim;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.ReportClaimMessageContextTestDataFactory.aReportClaimMessageContextWithoutDecision;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.EXPECTED_DELIVERY_DATE_IN_TWO_MONTHS;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.NOT_PREGNANT;
-import static uk.gov.dhsc.htbhf.eligibility.model.testhelper.CombinedIdAndEligibilityResponseTestDataFactory.anIdMatchedEligibilityConfirmedUCResponseWithAllMatches;
 
 @ExtendWith(MockitoExtension.class)
 class ReportClaimPropertiesFactoryTest extends ReportPropertiesFactoryTest {
@@ -78,7 +75,8 @@ class ReportClaimPropertiesFactoryTest extends ReportPropertiesFactoryTest {
         int secondsSinceEvent = 1;
         LocalDateTime timestamp = LocalDateTime.now().minusSeconds(secondsSinceEvent);
         List<LocalDate> datesOfBirthOfChildren = singletonList(LocalDate.now().minusMonths(11));
-        ReportClaimMessageContext context = aReportClaimMessageContextWithoutDecision(timestamp, datesOfBirthOfChildren);
+        ReportClaimMessageContext context = aReportClaimMessageContextWithoutDecision(timestamp,
+                datesOfBirthOfChildren);
         given(claimantCategoryCalculator.determineClaimantCategory(any(), any(), any())).willReturn(CLAIMANT_CATEGORY);
 
         Map<String, String> reportProperties = reportClaimPropertiesFactory.createReportPropertiesForClaimEvent(context);
@@ -189,42 +187,5 @@ class ReportClaimPropertiesFactoryTest extends ReportPropertiesFactoryTest {
         assertThat(reportProperties).contains(entry("cm3", "0"));
         assertThat(reportProperties).doesNotContainKey("cm9");
         assertThat(reportProperties).doesNotContainKey("cd11");
-    }
-
-    private ReportClaimMessageContext aReportClaimMessageContextForAnUpdatedClaim(LocalDateTime timestamp,
-                                                                                  List<LocalDate> datesOfBirthOfChildren,
-                                                                                  LocalDate expectedDeliveryDate,
-                                                                                  List<UpdatableClaimantField> updatedClaimantFields) {
-        return aReportClaimMessageContextBuilder(timestamp, datesOfBirthOfChildren, expectedDeliveryDate)
-                .updatedClaimantFields(updatedClaimantFields)
-                .claimAction(UPDATED)
-                .build();
-    }
-
-    private ReportClaimMessageContext aReportClaimMessageContext(LocalDateTime timestamp,
-                                                                 List<LocalDate> datesOfBirthOfChildren,
-                                                                 LocalDate expectedDeliveryDate) {
-        return aReportClaimMessageContextBuilder(timestamp, datesOfBirthOfChildren, expectedDeliveryDate).build();
-    }
-
-    private ReportClaimMessageContext.ReportClaimMessageContextBuilder aReportClaimMessageContextBuilder(LocalDateTime timestamp,
-                                                                                                         List<LocalDate> datesOfBirthOfChildren,
-                                                                                                         LocalDate expectedDeliveryDate) {
-        Claim claim = aClaimWithDueDateAndPostcodeData(expectedDeliveryDate);
-        return ReportClaimMessageContext.builder()
-                .claimAction(NEW)
-                .claim(claim)
-                .identityAndEligibilityResponse(anIdMatchedEligibilityConfirmedUCResponseWithAllMatches(datesOfBirthOfChildren))
-                .timestamp(timestamp);
-    }
-
-    private ReportClaimMessageContext aReportClaimMessageContextWithoutDecision(LocalDateTime timestamp, List<LocalDate> datesOfBirthOfChildren) {
-        Claim claim = aClaimWithChildrenDobAndDueDateAndPostcodeData(NOT_PREGNANT, datesOfBirthOfChildren);
-        return ReportClaimMessageContext.builder()
-                .claimAction(NEW)
-                .claim(claim)
-                .identityAndEligibilityResponse(null)
-                .timestamp(timestamp)
-                .build();
     }
 }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/ClaimTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/ClaimTestDataFactory.java
@@ -16,6 +16,7 @@ import static uk.gov.dhsc.htbhf.TestConstants.DWP_HOUSEHOLD_IDENTIFIER;
 import static uk.gov.dhsc.htbhf.TestConstants.HMRC_HOUSEHOLD_IDENTIFIER;
 import static uk.gov.dhsc.htbhf.TestConstants.SIMPSONS_POSTCODE;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimantTestDataFactory.aClaimantWithExpectedDeliveryDate;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimantTestDataFactory.aClaimantWithExpectedDeliveryDateAndChildrenDob;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimantTestDataFactory.aValidClaimant;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.PostcodeDataTestDataFactory.aPostcodeDataObjectForPostcode;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.CARD_ACCOUNT_ID;
@@ -92,6 +93,14 @@ public class ClaimTestDataFactory {
 
     public static Claim aClaimWithDueDateAndPostcodeData(LocalDate expectedDeliveryDate) {
         Claimant claimant = aClaimantWithExpectedDeliveryDate(expectedDeliveryDate);
+        return aValidClaimBuilder()
+                .claimant(claimant)
+                .postcodeData(aPostcodeDataObjectForPostcode(SIMPSONS_POSTCODE))
+                .build();
+    }
+
+    public static Claim aClaimWithChildrenDobAndDueDateAndPostcodeData(LocalDate expectedDeliveryDate, List<LocalDate> datesOfBirthOfChildren) {
+        Claimant claimant = aClaimantWithExpectedDeliveryDateAndChildrenDob(expectedDeliveryDate, datesOfBirthOfChildren);
         return aValidClaimBuilder()
                 .claimant(claimant)
                 .postcodeData(aPostcodeDataObjectForPostcode(SIMPSONS_POSTCODE))

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/ReportClaimMessageContextTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/ReportClaimMessageContextTestDataFactory.java
@@ -4,6 +4,7 @@ import uk.gov.dhsc.htbhf.claimant.entity.Claim;
 import uk.gov.dhsc.htbhf.claimant.message.context.ReportClaimMessageContext;
 import uk.gov.dhsc.htbhf.claimant.model.UpdatableClaimantField;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -11,7 +12,11 @@ import static uk.gov.dhsc.htbhf.TestConstants.SINGLE_THREE_YEAR_OLD;
 import static uk.gov.dhsc.htbhf.claimant.model.UpdatableClaimantField.FIRST_NAME;
 import static uk.gov.dhsc.htbhf.claimant.model.UpdatableClaimantField.LAST_NAME;
 import static uk.gov.dhsc.htbhf.claimant.reporting.ClaimAction.NEW;
+import static uk.gov.dhsc.htbhf.claimant.reporting.ClaimAction.UPDATED;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimTestDataFactory.aClaimWithChildrenDobAndDueDateAndPostcodeData;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimTestDataFactory.aClaimWithDueDateAndPostcodeData;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimTestDataFactory.aValidClaim;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.NOT_PREGNANT;
 import static uk.gov.dhsc.htbhf.eligibility.model.testhelper.CombinedIdAndEligibilityResponseTestDataFactory.anIdMatchedEligibilityConfirmedUCResponseWithAllMatches;
 
 public class ReportClaimMessageContextTestDataFactory {
@@ -21,6 +26,43 @@ public class ReportClaimMessageContextTestDataFactory {
                 .updatedClaimantFields(updatedFields)
                 .claim(claim)
                 .build();
+    }
+
+    public static ReportClaimMessageContext aReportClaimMessageContextForAnUpdatedClaim(LocalDateTime timestamp,
+                                                                                  List<LocalDate> datesOfBirthOfChildren,
+                                                                                  LocalDate expectedDeliveryDate,
+                                                                                  List<UpdatableClaimantField> updatedClaimantFields) {
+        return aReportClaimMessageContextBuilder(timestamp, datesOfBirthOfChildren, expectedDeliveryDate)
+                .updatedClaimantFields(updatedClaimantFields)
+                .claimAction(UPDATED)
+                .build();
+    }
+
+    public static ReportClaimMessageContext aReportClaimMessageContext(LocalDateTime timestamp,
+                                                                 List<LocalDate> datesOfBirthOfChildren,
+                                                                 LocalDate expectedDeliveryDate) {
+        return aReportClaimMessageContextBuilder(timestamp, datesOfBirthOfChildren, expectedDeliveryDate).build();
+    }
+
+    public static ReportClaimMessageContext aReportClaimMessageContextWithoutDecision(LocalDateTime timestamp, List<LocalDate> datesOfBirthOfChildren) {
+        Claim claim = aClaimWithChildrenDobAndDueDateAndPostcodeData(NOT_PREGNANT, datesOfBirthOfChildren);
+        return ReportClaimMessageContext.builder()
+                .claimAction(NEW)
+                .claim(claim)
+                .identityAndEligibilityResponse(null)
+                .timestamp(timestamp)
+                .build();
+    }
+
+    private static ReportClaimMessageContext.ReportClaimMessageContextBuilder aReportClaimMessageContextBuilder(LocalDateTime timestamp,
+                                                                                                                List<LocalDate> datesOfBirthOfChildren,
+                                                                                                                LocalDate expectedDeliveryDate) {
+        Claim claim = aClaimWithDueDateAndPostcodeData(expectedDeliveryDate);
+        return ReportClaimMessageContext.builder()
+                .claimAction(NEW)
+                .claim(claim)
+                .identityAndEligibilityResponse(anIdMatchedEligibilityConfirmedUCResponseWithAllMatches(datesOfBirthOfChildren))
+                .timestamp(timestamp);
     }
 
     // Without <?, ?> at the end of ReportClaimMessageContextBuilder, an instance of ReportEventMessageContextBuilder is returned instead


### PR DESCRIPTION
When reporting a claim and creating the common custom dimensions for calling google analytics, we obtain the children's DOB from the identityAndEligibilityresponse. However, if a claim was rejected due to a duplicate NINO, we never call the eligibility service, so this object is never populated. The factory should instead check for a null value and obtain the children's dob from the claim instead.