### PR TITLE
Feature/eligibility override json column

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/entity/Claim.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/entity/Claim.java
@@ -92,7 +92,8 @@ public class Claim extends VersionedEntity {
     private Claimant claimant;
 
     @ValidEligibilityOverride(message = "Must be either null or have all fields populated")
-    @Embedded
+    @Column(name  = "eligibility_override")
+    @Type(type = JSON_TYPE)
     private EligibilityOverride eligibilityOverride;
 
     public void updateClaimStatus(ClaimStatus newStatus) {

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/entity/EligibilityOverride.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/entity/EligibilityOverride.java
@@ -21,7 +21,7 @@ import static uk.gov.dhsc.htbhf.claimant.entity.BaseEntity.JSON_TYPE;
 @AllArgsConstructor(onConstructor_ = {@JsonCreator})
 public class EligibilityOverride {
 
-    @JsonProperty("overrideOutcome")
+    @JsonProperty("eligibilityOutcome")
     @Enumerated(EnumType.STRING)
     private EligibilityOutcome eligibilityOutcome;
 

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/entity/EligibilityOverride.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/entity/EligibilityOverride.java
@@ -1,34 +1,34 @@
 package uk.gov.dhsc.htbhf.claimant.entity;
 
-import lombok.*;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
 import org.hibernate.annotations.Type;
 import uk.gov.dhsc.htbhf.claimant.model.constraint.ListOfDatesInPast;
 import uk.gov.dhsc.htbhf.dwp.model.EligibilityOutcome;
 
 import java.time.LocalDate;
 import java.util.List;
-import javax.persistence.Column;
-import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 
 import static uk.gov.dhsc.htbhf.claimant.entity.BaseEntity.JSON_TYPE;
 
-@Builder
 @Data
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-@Embeddable
+@Builder
+@AllArgsConstructor(onConstructor_ = {@JsonCreator})
 public class EligibilityOverride {
 
-    @Column(name = "eligibility_override_outcome")
+    @JsonProperty("overrideOutcome")
     @Enumerated(EnumType.STRING)
     private EligibilityOutcome eligibilityOutcome;
 
-    @Column(name = "eligibility_override_until")
+    @JsonProperty("overrideUntil")
     private LocalDate overrideUntil;
 
-    @Column(name = "eligibility_override_children_dob")
+    @JsonProperty("childrenDob")
     @Type(type = JSON_TYPE)
     @ListOfDatesInPast(message = "dates of birth of children should be all in the past")
     private List<LocalDate> childrenDob;

--- a/db/src/main/resources/db/migration/V1_060__add_eligibility_override_json_to_claim.sql
+++ b/db/src/main/resources/db/migration/V1_060__add_eligibility_override_json_to_claim.sql
@@ -1,0 +1,11 @@
+alter table claim ADD COLUMN eligibility_override json;
+
+UPDATE claim AS c1
+SET eligibility_override = (
+  SELECT row_to_json(t) FROM (
+    SELECT eligibility_override_outcome as "eligibilityOutcome",
+           eligibility_override_until as "overrideUntil",
+           eligibility_override_children_dob as "childrenDob"
+    FROM claim AS c2 WHERE c1.id = c2.id and eligibility_override_outcome is not null
+  ) t
+)::jsonb;


### PR DESCRIPTION
Qualifying benefits will be added to EligibilityOverride as part of AFHS-796 to set qualifying benefits to under_18.  
Converted existing 3 override columns to eligibility_override json column  to keep all 3 fields ( +1 in next pr) as part of json in eligibility_override. This is to avoid many columns in claim table  for eligibility override