### PR TITLE
AFHS-1956 - modified nino,email and phone number to be optional. 

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/communications/DetermineEntitlementNotificationHandler.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/communications/DetermineEntitlementNotificationHandler.java
@@ -20,14 +20,14 @@ public class DetermineEntitlementNotificationHandler {
 
     private final MessageQueueClient messageQueueClient;
 
-    public void sendClaimNoLongerEligibleEmail(Claim claim) {
+    public void sendClaimNoLongerEligibleEmailIfPresent(Claim claim) {
         if (StringUtils.isNotEmpty(claim.getClaimant().getEmailAddress())) {
             MessagePayload messagePayload = buildClaimIsNoLongerEligibleNotificationEmailPayload(claim);
             messageQueueClient.sendMessage(messagePayload, SEND_EMAIL);
         }
     }
 
-    public void sendNoChildrenOnFeedClaimNoLongerEligibleEmail(Claim claim) {
+    public void sendNoChildrenOnFeedClaimNoLongerEligibleEmailIfPresent(Claim claim) {
         if (StringUtils.isNotEmpty(claim.getClaimant().getEmailAddress())) {
             MessagePayload messagePayload = buildNoChildrenOnFeedClaimIsNoLongerEligibleNotificationEmailPayload(claim);
             messageQueueClient.sendMessage(messagePayload, SEND_EMAIL);

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/communications/DetermineEntitlementNotificationHandler.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/communications/DetermineEntitlementNotificationHandler.java
@@ -1,6 +1,7 @@
 package uk.gov.dhsc.htbhf.claimant.communications;
 
 import lombok.AllArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.dhsc.htbhf.claimant.entity.Claim;
 import uk.gov.dhsc.htbhf.claimant.message.MessageQueueClient;
@@ -20,13 +21,17 @@ public class DetermineEntitlementNotificationHandler {
     private final MessageQueueClient messageQueueClient;
 
     public void sendClaimNoLongerEligibleEmail(Claim claim) {
-        MessagePayload messagePayload = buildClaimIsNoLongerEligibleNotificationEmailPayload(claim);
-        messageQueueClient.sendMessage(messagePayload, SEND_EMAIL);
+        if (StringUtils.isNotEmpty(claim.getClaimant().getEmailAddress())) {
+            MessagePayload messagePayload = buildClaimIsNoLongerEligibleNotificationEmailPayload(claim);
+            messageQueueClient.sendMessage(messagePayload, SEND_EMAIL);
+        }
     }
 
     public void sendNoChildrenOnFeedClaimNoLongerEligibleEmail(Claim claim) {
-        MessagePayload messagePayload = buildNoChildrenOnFeedClaimIsNoLongerEligibleNotificationEmailPayload(claim);
-        messageQueueClient.sendMessage(messagePayload, SEND_EMAIL);
+        if (StringUtils.isNotEmpty(claim.getClaimant().getEmailAddress())) {
+            MessagePayload messagePayload = buildNoChildrenOnFeedClaimIsNoLongerEligibleNotificationEmailPayload(claim);
+            messageQueueClient.sendMessage(messagePayload, SEND_EMAIL);
+        }
     }
 
     private EmailMessagePayload buildClaimIsNoLongerEligibleNotificationEmailPayload(Claim claim) {

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/communications/PaymentCycleNotificationHandler.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/communications/PaymentCycleNotificationHandler.java
@@ -32,7 +32,7 @@ public class PaymentCycleNotificationHandler {
         EmailType emailType = voucherEntitlementIndicatesNewChildFromPregnancy(paymentCycle)
                 ? EmailType.NEW_CHILD_FROM_PREGNANCY
                 : EmailType.REGULAR_PAYMENT;
-        sendNotificationEmail(paymentCycle, emailType);
+        sendNotificationEmailIfPresent(paymentCycle, emailType);
     }
 
     /**
@@ -42,10 +42,10 @@ public class PaymentCycleNotificationHandler {
      * @param paymentCycle the current payment cycle
      */
     public void sendNotificationEmailsForRestartedPayment(PaymentCycle paymentCycle) {
-        sendNotificationEmail(paymentCycle, EmailType.RESTARTED_PAYMENT);
+        sendNotificationEmailIfPresent(paymentCycle, EmailType.RESTARTED_PAYMENT);
     }
 
-    private void sendNotificationEmail(PaymentCycle paymentCycle, EmailType emailType) {
+    private void sendNotificationEmailIfPresent(PaymentCycle paymentCycle, EmailType emailType) {
         if (StringUtils.isNotEmpty(paymentCycle.getClaim().getClaimant().getEmailAddress())) {
             EmailMessagePayload messagePayload = emailMessagePayloadFactory.buildEmailMessagePayload(paymentCycle, emailType);
             messageQueueClient.sendMessage(messagePayload, MessageType.SEND_EMAIL);

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/communications/PaymentCycleNotificationHandler.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/communications/PaymentCycleNotificationHandler.java
@@ -1,6 +1,7 @@
 package uk.gov.dhsc.htbhf.claimant.communications;
 
 import lombok.AllArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.dhsc.htbhf.claimant.entitlement.PregnancyEntitlementCalculator;
 import uk.gov.dhsc.htbhf.claimant.entity.PaymentCycle;
@@ -45,9 +46,11 @@ public class PaymentCycleNotificationHandler {
     }
 
     private void sendNotificationEmail(PaymentCycle paymentCycle, EmailType emailType) {
-        EmailMessagePayload messagePayload = emailMessagePayloadFactory.buildEmailMessagePayload(paymentCycle, emailType);
-        messageQueueClient.sendMessage(messagePayload, MessageType.SEND_EMAIL);
-        handleUpcomingBirthdayEmails(paymentCycle);
+        if (StringUtils.isNotEmpty(paymentCycle.getClaim().getClaimant().getEmailAddress())) {
+            EmailMessagePayload messagePayload = emailMessagePayloadFactory.buildEmailMessagePayload(paymentCycle, emailType);
+            messageQueueClient.sendMessage(messagePayload, MessageType.SEND_EMAIL);
+            handleUpcomingBirthdayEmails(paymentCycle);
+        }
     }
 
     private boolean voucherEntitlementIndicatesNewChildFromPregnancy(PaymentCycle paymentCycle) {

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/eligibility/EligibilityDecisionHandler.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/eligibility/EligibilityDecisionHandler.java
@@ -82,7 +82,7 @@ public class EligibilityDecisionHandler {
             handleLossOfQualifyingReasonStatus(claim, decision.getIdentityAndEligibilityResponse());
         } else {
             expireClaim(claim, decision.getIdentityAndEligibilityResponse(), UPDATED_FROM_ACTIVE_TO_EXPIRED);
-            determineEntitlementNotificationHandler.sendNoChildrenOnFeedClaimNoLongerEligibleEmail(claim);
+            determineEntitlementNotificationHandler.sendNoChildrenOnFeedClaimNoLongerEligibleEmailIfPresent(claim);
         }
     }
 
@@ -113,7 +113,7 @@ public class EligibilityDecisionHandler {
 
     private void handleLossOfQualifyingReasonStatus(Claim claim, CombinedIdentityAndEligibilityResponse identityAndEligibilityResponse) {
         updateClaimAndCardStatus(claim, PENDING_EXPIRY, PENDING_CANCELLATION);
-        determineEntitlementNotificationHandler.sendClaimNoLongerEligibleEmail(claim);
+        determineEntitlementNotificationHandler.sendClaimNoLongerEligibleEmailIfPresent(claim);
         claimMessageSender.sendReportClaimMessage(claim, identityAndEligibilityResponse, UPDATED_FROM_ACTIVE_TO_PENDING_EXPIRY);
     }
 

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/eligibility/EligibilityDecisionHandler.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/eligibility/EligibilityDecisionHandler.java
@@ -1,6 +1,7 @@
 package uk.gov.dhsc.htbhf.claimant.eligibility;
 
 import lombok.AllArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.dhsc.htbhf.claimant.communications.DetermineEntitlementNotificationHandler;
 import uk.gov.dhsc.htbhf.claimant.entitlement.PregnancyEntitlementCalculator;
@@ -54,7 +55,8 @@ public class EligibilityDecisionHandler {
             createMakeRestartedPaymentMessage(currentPaymentCycle);
         }
 
-        if (pregnancyEntitlementCalculator.currentCycleIsSecondToLastCycleWithPregnancyVouchers(currentPaymentCycle)) {
+        if (pregnancyEntitlementCalculator.currentCycleIsSecondToLastCycleWithPregnancyVouchers(currentPaymentCycle)
+                && StringUtils.isNotEmpty(claim.getClaimant().getEmailAddress())) {
             // Email is worded such that we don't need to check if a new child from pregnancy has already appeared.
             claimMessageSender.sendReportABirthEmailMessage(claim);
         }

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/entity/Claimant.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/entity/Claimant.java
@@ -35,7 +35,6 @@ public class Claimant {
     @Column(name = "last_name")
     private String lastName;
 
-    @NotNull
     @Pattern(regexp = "[a-zA-Z]{2}\\d{6}[a-dA-D]")
     @Column(name = "nino")
     private String nino;
@@ -53,12 +52,10 @@ public class Claimant {
     @OneToOne(cascade = CascadeType.ALL)
     private Address address;
 
-    @NotNull
     @Pattern(regexp = "^\\+44\\d{9,10}$", message = "invalid UK phone number, must be in +447123456789 format")
     @Column(name = "phone_number")
     private String phoneNumber;
 
-    @NotNull
     @Pattern(regexp = VALID_EMAIL_REGEX, message = "invalid email address")
     @Size(max = 256)
     @Column(name = "email_address")

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/model/ClaimantDTO.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/model/ClaimantDTO.java
@@ -43,7 +43,6 @@ public class ClaimantDTO {
     @ApiModelProperty(notes = "Last (surname or family) name", example = "Bloggs")
     private String lastName;
 
-    @NotNull
     @Pattern(regexp = "^(?!BG|GB|NK|KN|TN|NT|ZZ)[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z](\\d{6})[A-D]$")
     @JsonProperty("nino")
     @ApiModelProperty(notes = "National Insurance number", example = "QQ123456C")
@@ -69,13 +68,11 @@ public class ClaimantDTO {
     @ApiModelProperty(notes = "The address of the claimant")
     private AddressDTO address;
 
-    @NotNull
     @Pattern(regexp = "^\\+44\\d{9,10}$", message = "invalid UK phone number, must be in +44 format, e.g. +447123456789")
     @JsonProperty("phoneNumber")
     @ApiModelProperty(notes = "The claimant's UK phone number. Must be in +44 format, e.g. +447123456789", example = "+447123456789")
     private String phoneNumber;
 
-    @NotNull
     @Pattern(regexp = VALID_EMAIL_REGEX_V3, message = "invalid email address")
     @Size(max = 256)
     @JsonProperty("emailAddress")

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/reporting/payload/ReportPropertiesFactory.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/reporting/payload/ReportPropertiesFactory.java
@@ -87,12 +87,15 @@ public abstract class ReportPropertiesFactory {
 
         CombinedIdentityAndEligibilityResponse identityAndEligibilityResponse = context.getIdentityAndEligibilityResponse();
         List<LocalDate> dobOfChildrenUnder4 = getDobOfChildrenUnder4(claim, identityAndEligibilityResponse);
+        //current identity and eligibility response will be null in case of duplicate rejected claims
+        QualifyingReason qualifyingReason = claim.getCurrentIdentityAndEligibilityResponse() == null
+                ? QualifyingReason.NOT_SET : claim.getCurrentIdentityAndEligibilityResponse().getQualifyingReason();
 
         ClaimantCategory claimantCategory = claimantCategoryCalculator.determineClaimantCategory(
                         claim.getClaimant(),
                         dobOfChildrenUnder4,
                         context.getTimestamp().toLocalDate(),
-                        claim.getCurrentIdentityAndEligibilityResponse().getQualifyingReason());
+                        qualifyingReason);
 
         customDimensions.put(CLAIMANT_CATEGORY.getFieldName(), claimantCategory.getDescription());
         PostcodeData postcodeData = claim.getPostcodeData();

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/scheduler/HandleCardPendingCancellationJob.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/scheduler/HandleCardPendingCancellationJob.java
@@ -2,6 +2,7 @@ package uk.gov.dhsc.htbhf.claimant.scheduler;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.dhsc.htbhf.claimant.entity.Claim;
 import uk.gov.dhsc.htbhf.claimant.message.MessageQueueClient;
@@ -30,7 +31,11 @@ public class HandleCardPendingCancellationJob {
     @Transactional
     public void handleCardPendingCancellation(Claim claim) {
         MessagePayload messagePayload = buildEmailMessagePayloadWithFirstAndLastNameOnly(claim, CARD_IS_ABOUT_TO_BE_CANCELLED);
-        messageQueueClient.sendMessage(messagePayload, SEND_EMAIL);
+
+        if (StringUtils.isNotEmpty(claim.getClaimant().getEmailAddress())) {
+            messageQueueClient.sendMessage(messagePayload, SEND_EMAIL);
+        }
+
         claim.updateCardStatus(SCHEDULED_FOR_CANCELLATION);
         claimRepository.save(claim);
     }

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/claim/ClaimService.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/claim/ClaimService.java
@@ -76,7 +76,9 @@ public class ClaimService {
                 return ClaimResult.withEntitlement(claim, weeklyEntitlement, verificationResult);
             }
 
-            sendMessagesForRejectedClaim(identityAndEligibilityResponse, verificationResult, claim);
+            if (StringUtils.isNotEmpty(claim.getClaimant().getNino())) {
+                sendMessagesForRejectedClaimIfNinoPresent(identityAndEligibilityResponse, verificationResult, claim);
+            }
             return ClaimResult.withNoEntitlement(claim, verificationResult);
         } catch (RuntimeException e) {
             handleFailedClaim(claimRequest, e);
@@ -112,9 +114,9 @@ public class ClaimService {
         claimMessageSender.sendLetterWithAddressAndPaymentFieldsMessage(claim, decision, letterType);
     }
 
-    private void sendMessagesForRejectedClaim(CombinedIdentityAndEligibilityResponse identityAndEligibilityResponse,
-                                              VerificationResult verificationResult,
-                                              Claim claim) {
+    private void sendMessagesForRejectedClaimIfNinoPresent(CombinedIdentityAndEligibilityResponse identityAndEligibilityResponse,
+                                                           VerificationResult verificationResult,
+                                                           Claim claim) {
         if (verificationResult.isAddressMismatch()) {
             if (StringUtils.isNotEmpty(claim.getClaimant().getEmailAddress())) {
                 claimMessageSender.sendDecisionPendingEmailMessage(claim);

--- a/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/claim/ClaimService.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/claimant/service/claim/ClaimService.java
@@ -4,6 +4,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import uk.gov.dhsc.htbhf.claimant.entitlement.VoucherEntitlement;
 import uk.gov.dhsc.htbhf.claimant.entity.Claim;
@@ -20,6 +21,7 @@ import uk.gov.dhsc.htbhf.claimant.service.ClaimResult;
 import uk.gov.dhsc.htbhf.claimant.service.EligibilityAndEntitlementService;
 import uk.gov.dhsc.htbhf.claimant.service.audit.EventAuditor;
 import uk.gov.dhsc.htbhf.claimant.service.audit.NewClaimEvent;
+import uk.gov.dhsc.htbhf.dwp.model.VerificationOutcome;
 import uk.gov.dhsc.htbhf.eligibility.model.CombinedIdentityAndEligibilityResponse;
 import uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus;
 import uk.gov.dhsc.htbhf.logging.event.FailureEvent;
@@ -85,7 +87,7 @@ public class ClaimService {
     private void sendMessagesForNewClaim(EligibilityAndEntitlementDecision decision,
                                          CombinedIdentityAndEligibilityResponse identityAndEligibilityResponse,
                                          Claim claim) {
-        if (identityAndEligibilityResponse.isEmailAndPhoneMatched()) {
+        if (identityAndEligibilityResponse.getEmailAddressMatch() == VerificationOutcome.MATCHED) {
             EmailType emailType = registeredChildrenContainAllDeclaredChildren(identityAndEligibilityResponse, claim)
                     ? EmailType.INSTANT_SUCCESS
                     : EmailType.INSTANT_SUCCESS_PARTIAL_CHILDREN_MATCH;
@@ -93,6 +95,7 @@ public class ClaimService {
         } else {
             sendMessagesForPhoneOrEmailMismatch(claim, decision, identityAndEligibilityResponse);
         }
+
         claimMessageSender.sendNewCardMessage(claim, decision);
         claimMessageSender.sendReportClaimMessage(claim, identityAndEligibilityResponse, ClaimAction.NEW);
     }
@@ -100,8 +103,9 @@ public class ClaimService {
     private void sendMessagesForPhoneOrEmailMismatch(Claim claim,
                                                      EligibilityAndEntitlementDecision decision,
                                                      CombinedIdentityAndEligibilityResponse identityAndEligibilityResponse) {
-        claimMessageSender.sendDecisionPendingEmailMessage(claim);
-
+        if (StringUtils.isNotEmpty(claim.getClaimant().getEmailAddress())) {
+            claimMessageSender.sendDecisionPendingEmailMessage(claim);
+        }
         LetterType letterType = registeredChildrenContainAllDeclaredChildren(identityAndEligibilityResponse, claim)
                 ? LetterType.APPLICATION_SUCCESS_CHILDREN_MATCH
                 : LetterType.APPLICATION_SUCCESS_CHILDREN_MISMATCH;
@@ -112,7 +116,9 @@ public class ClaimService {
                                               VerificationResult verificationResult,
                                               Claim claim) {
         if (verificationResult.isAddressMismatch()) {
-            claimMessageSender.sendDecisionPendingEmailMessage(claim);
+            if (StringUtils.isNotEmpty(claim.getClaimant().getEmailAddress())) {
+                claimMessageSender.sendDecisionPendingEmailMessage(claim);
+            }
             claimMessageSender.sendLetterWithAddressOnlyMessage(claim, LetterType.UPDATE_YOUR_ADDRESS);
         }
         claimMessageSender.sendReportClaimMessage(claim, identityAndEligibilityResponse, ClaimAction.REJECTED);

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/communications/DetermineEntitlementNotificationHandlerTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/communications/DetermineEntitlementNotificationHandlerTest.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static uk.gov.dhsc.htbhf.claimant.message.EmailPayloadAssertions.assertEmailPayloadCorrectWithFirstAndLastName;
 import static uk.gov.dhsc.htbhf.claimant.message.MessageType.SEND_EMAIL;
 import static uk.gov.dhsc.htbhf.claimant.message.payload.EmailType.NO_CHILD_ON_FEED_NO_LONGER_ELIGIBLE;
@@ -47,6 +48,14 @@ class DetermineEntitlementNotificationHandlerTest {
     }
 
     @Test
+    public void shouldNotPutClaimNoLongerEligibleMessageOnQueueForMissingEmail() {
+        Claim claim = aValidClaim();
+        claim.getClaimant().setEmailAddress(null);
+        determineEntitlementNotificationHandler.sendClaimNoLongerEligibleEmail(claim);
+        verifyNoInteractions(messageQueueClient);
+    }
+
+    @Test
     public void shouldPutNoChildrenOnFeedClaimNoLongerEligibleMessageOnQueue() {
         Claim claim = aValidClaim();
 
@@ -56,5 +65,14 @@ class DetermineEntitlementNotificationHandlerTest {
         verify(messageQueueClient).sendMessage(argumentCaptor.capture(), eq(SEND_EMAIL));
         EmailMessagePayload payload = argumentCaptor.getValue();
         assertEmailPayloadCorrectWithFirstAndLastName(payload, claim, NO_CHILD_ON_FEED_NO_LONGER_ELIGIBLE);
+    }
+
+    @Test
+    public void shouldNotPutNoChildrenOnFeedClaimNoLongerEligibleMessageOnQueue() {
+        Claim claim = aValidClaim();
+        claim.getClaimant().setEmailAddress(null);
+        determineEntitlementNotificationHandler.sendNoChildrenOnFeedClaimNoLongerEligibleEmail(claim);
+        verifyNoInteractions(messageQueueClient);
+
     }
 }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/communications/DetermineEntitlementNotificationHandlerTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/communications/DetermineEntitlementNotificationHandlerTest.java
@@ -34,7 +34,7 @@ class DetermineEntitlementNotificationHandlerTest {
     public void shouldPutClaimNoLongerEligibleMessageOnQueue() {
         Claim claim = aValidClaim();
 
-        determineEntitlementNotificationHandler.sendClaimNoLongerEligibleEmail(claim);
+        determineEntitlementNotificationHandler.sendClaimNoLongerEligibleEmailIfPresent(claim);
 
         ArgumentCaptor<EmailMessagePayload> argumentCaptor = ArgumentCaptor.forClass(EmailMessagePayload.class);
         verify(messageQueueClient).sendMessage(argumentCaptor.capture(), eq(SEND_EMAIL));
@@ -51,7 +51,7 @@ class DetermineEntitlementNotificationHandlerTest {
     public void shouldNotPutClaimNoLongerEligibleMessageOnQueueForMissingEmail() {
         Claim claim = aValidClaim();
         claim.getClaimant().setEmailAddress(null);
-        determineEntitlementNotificationHandler.sendClaimNoLongerEligibleEmail(claim);
+        determineEntitlementNotificationHandler.sendClaimNoLongerEligibleEmailIfPresent(claim);
         verifyNoInteractions(messageQueueClient);
     }
 
@@ -59,7 +59,7 @@ class DetermineEntitlementNotificationHandlerTest {
     public void shouldPutNoChildrenOnFeedClaimNoLongerEligibleMessageOnQueue() {
         Claim claim = aValidClaim();
 
-        determineEntitlementNotificationHandler.sendNoChildrenOnFeedClaimNoLongerEligibleEmail(claim);
+        determineEntitlementNotificationHandler.sendNoChildrenOnFeedClaimNoLongerEligibleEmailIfPresent(claim);
 
         ArgumentCaptor<EmailMessagePayload> argumentCaptor = ArgumentCaptor.forClass(EmailMessagePayload.class);
         verify(messageQueueClient).sendMessage(argumentCaptor.capture(), eq(SEND_EMAIL));
@@ -71,7 +71,7 @@ class DetermineEntitlementNotificationHandlerTest {
     public void shouldNotPutNoChildrenOnFeedClaimNoLongerEligibleMessageOnQueue() {
         Claim claim = aValidClaim();
         claim.getClaimant().setEmailAddress(null);
-        determineEntitlementNotificationHandler.sendNoChildrenOnFeedClaimNoLongerEligibleEmail(claim);
+        determineEntitlementNotificationHandler.sendNoChildrenOnFeedClaimNoLongerEligibleEmailIfPresent(claim);
         verifyNoInteractions(messageQueueClient);
 
     }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/communications/PaymentCycleNotificationHandlerTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/communications/PaymentCycleNotificationHandlerTest.java
@@ -173,6 +173,18 @@ class PaymentCycleNotificationHandlerTest {
         verifyNoMoreInteractions(upcomingBirthdayEmailHandler);
     }
 
+    @Test
+    public void shouldNotSendAnyNotificationForMissingEmail() {
+        PaymentCycle paymentCycle = aValidPaymentCycle();
+        paymentCycle.getClaim().getClaimant().setEmailAddress(null);
+        paymentCycleNotificationHandler.sendNotificationEmailsForRegularPayment(paymentCycle);
+        verifyNoInteractions(messageQueueClient);
+        verifyNoInteractions(emailMessagePayloadFactory);
+        verifyNoInteractions(pregnancyEntitlementCalculator);
+        verifyNoInteractions(childDateOfBirthCalculator);
+        verifyNoInteractions(upcomingBirthdayEmailHandler);
+    }
+
     private void verifyPaymentEmailNotificationSent(PaymentCycle paymentCycle, EmailMessagePayload emailMessagePayload, EmailType emailType) {
         verify(messageQueueClient).sendMessage(emailMessagePayload, MessageType.SEND_EMAIL);
         verify(emailMessagePayloadFactory).buildEmailMessagePayload(paymentCycle, emailType);

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/eligibility/EligibilityDecisionHandlerTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/eligibility/EligibilityDecisionHandlerTest.java
@@ -200,7 +200,7 @@ class EligibilityDecisionHandlerTest {
 
         //Then
         verifyClaimSavedWithStatus(ClaimStatus.EXPIRED, PENDING_CANCELLATION);
-        verify(determineEntitlementNotificationHandler).sendNoChildrenOnFeedClaimNoLongerEligibleEmail(claimAtCurrentCycle);
+        verify(determineEntitlementNotificationHandler).sendNoChildrenOnFeedClaimNoLongerEligibleEmailIfPresent(claimAtCurrentCycle);
         LocalDate currentPaymentCycleStartDate = currentPaymentCycle.getCycleStartDate();
         verify(pregnancyEntitlementCalculator).claimantIsPregnantInCycle(currentPaymentCycle);
         verify(childDateOfBirthCalculator).hadChildrenUnder4AtStartOfPaymentCycle(previousPaymentCycle);
@@ -237,7 +237,7 @@ class EligibilityDecisionHandlerTest {
 
         //Then
         verifyClaimSavedWithStatus(ClaimStatus.PENDING_EXPIRY, PENDING_CANCELLATION);
-        verify(determineEntitlementNotificationHandler).sendClaimNoLongerEligibleEmail(claimAtCurrentCycle);
+        verify(determineEntitlementNotificationHandler).sendClaimNoLongerEligibleEmailIfPresent(claimAtCurrentCycle);
         LocalDate currentCycleStartDate = currentPaymentCycle.getCycleStartDate();
         verify(childDateOfBirthCalculator).hadChildrenUnder4AtStartOfPaymentCycle(previousPaymentCycle);
         verify(childDateOfBirthCalculator).hasChildrenUnderFourAtGivenDate(ONE_CHILD_UNDER_ONE_AND_ONE_CHILD_BETWEEN_ONE_AND_FOUR, currentCycleStartDate);
@@ -267,7 +267,7 @@ class EligibilityDecisionHandlerTest {
 
         //Then
         verifyClaimSavedWithStatus(ClaimStatus.PENDING_EXPIRY, PENDING_CANCELLATION);
-        verify(determineEntitlementNotificationHandler).sendClaimNoLongerEligibleEmail(claimAtCurrentCycle);
+        verify(determineEntitlementNotificationHandler).sendClaimNoLongerEligibleEmailIfPresent(claimAtCurrentCycle);
         verify(pregnancyEntitlementCalculator).claimantIsPregnantInCycle(currentPaymentCycle);
         verify(claimMessageSender).sendReportClaimMessage(claimAtCurrentCycle,
                 decision.getIdentityAndEligibilityResponse(), UPDATED_FROM_ACTIVE_TO_PENDING_EXPIRY);

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/eligibility/EligibilityDecisionHandlerTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/eligibility/EligibilityDecisionHandlerTest.java
@@ -1,5 +1,6 @@
 package uk.gov.dhsc.htbhf.claimant.eligibility;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -107,10 +108,12 @@ class EligibilityDecisionHandlerTest {
         verify(pregnancyEntitlementCalculator).currentCycleIsSecondToLastCycleWithPregnancyVouchers(currentPaymentCycle);
     }
 
-    @Test
-    void shouldSendReportABirthReminderEmailWhenClaimantReceivesSecondToLastPregnancyVouchers() {
+    @ParameterizedTest
+    @MethodSource("emailAddresses")
+    void shouldSendReportABirthReminderEmailWhenClaimantReceivesSecondToLastPregnancyVouchers(String emailAddress) {
         // Given
         Claim claim = aValidClaim();
+        claim.getClaimant().setEmailAddress(emailAddress);
         PaymentCycle currentPaymentCycle = aPaymentCycleWithClaim(claim);
         // current payment cycle is second to last one with vouchers
         given(pregnancyEntitlementCalculator.currentCycleIsSecondToLastCycleWithPregnancyVouchers(any())).willReturn(true);
@@ -120,7 +123,19 @@ class EligibilityDecisionHandlerTest {
 
         // Then
         verify(pregnancyEntitlementCalculator).currentCycleIsSecondToLastCycleWithPregnancyVouchers(currentPaymentCycle);
-        verify(claimMessageSender).sendReportABirthEmailMessage(claim);
+        if (StringUtils.isEmpty(emailAddress)) {
+            verifyNoInteractions(claimMessageSender);
+        } else {
+            verify(claimMessageSender).sendReportABirthEmailMessage(claim);
+        }
+    }
+
+    private static Stream<Arguments> emailAddresses() {
+
+        return Stream.of(
+                Arguments.of(HOMER_EMAIL),
+                Arguments.of("")
+        );
     }
 
     //Test for HTBHF-2182 has the following context:

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/entity/ClaimantTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/entity/ClaimantTest.java
@@ -1,5 +1,6 @@
 package uk.gov.dhsc.htbhf.claimant.entity;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -98,6 +99,7 @@ class ClaimantTest extends AbstractValidationTest {
                 .hasViolation("size must be between 1 and 500", "firstName");
     }
 
+    @Disabled("nino is optional for private beta  and unique key is yet to be decided")
     @Test
     void shouldFailToValidateClaimantWithNoNino() {
         //Given
@@ -107,6 +109,28 @@ class ClaimantTest extends AbstractValidationTest {
         Set<ConstraintViolation<Claimant>> violations = validator.validate(claimant);
         //Then
         assertThat(violations).hasSingleConstraintViolation("must not be null", "nino");
+    }
+
+    @Test
+    void shouldValidateClaimantWithoutNino() {
+        //Given
+        String nino = null;
+        Claimant claimant = aClaimantWithNino(nino);
+        //When
+        Set<ConstraintViolation<Claimant>> violations = validator.validate(claimant);
+        //Then
+        assertThat(violations).hasNoViolations();
+    }
+
+    @Test
+    void shouldValidateClaimantWithoutEmail() {
+        //Given
+        String emailAddress = null;
+        Claimant claimant = aClaimantWithEmailAddress(emailAddress);
+        //When
+        Set<ConstraintViolation<Claimant>> violations = validator.validate(claimant);
+        //Then
+        assertThat(violations).hasNoViolations();
     }
 
     @ParameterizedTest
@@ -182,6 +206,7 @@ class ClaimantTest extends AbstractValidationTest {
         assertThat(violations).hasSingleConstraintViolation("must not be null", "address");
     }
 
+    @Disabled("phone number is optional for private beta  and unique key is yet to be decided")
     @Test
     void shouldFailToValidateClaimantWithoutPhoneNumber() {
         //Given
@@ -190,6 +215,16 @@ class ClaimantTest extends AbstractValidationTest {
         Set<ConstraintViolation<Claimant>> violations = validator.validate(claimant);
         //Then
         assertThat(violations).hasSingleConstraintViolation("must not be null", "phoneNumber");
+    }
+
+    @Test
+    void shouldValidateClaimantWithoutPhoneNumber() {
+        //Given
+        Claimant claimant = aClaimantWithPhoneNumber(null);
+        //When
+        Set<ConstraintViolation<Claimant>> violations = validator.validate(claimant);
+        //Then
+        assertThat(violations).hasNoViolations();
     }
 
     @ParameterizedTest

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/processor/EmailMessageProcessorTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/message/processor/EmailMessageProcessorTest.java
@@ -85,6 +85,27 @@ class EmailMessageProcessorTest {
     }
 
     @Test
+    void shouldNotSendMessageForMissingEmail() throws NotificationClientException {
+        //Given
+        Claim claim = aValidClaim();
+        claim.getClaimant().setEmailAddress(null);
+        Map<String, Object> emailPersonalisation = buildEmailPersonalisation();
+        EmailMessageContext context = EmailMessageContext.builder()
+                .claim(claim)
+                .emailPersonalisation(emailPersonalisation)
+                .emailType(INSTANT_SUCCESS)
+                .build();
+        given(messageContextLoader.loadEmailMessageContext(any())).willReturn(context);
+        Message message = aValidMessageWithType(SEND_EMAIL);
+
+        //When
+        emailMessageProcessor.processMessage(message);
+
+        //Then
+        verifyNoInteractions(client);
+    }
+
+    @Test
     void shouldNotLogEmailBodyOrSubject() throws NotificationClientException {
         //Given
         Claim claim = aValidClaim();

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/model/ClaimantDTOTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/model/ClaimantDTOTest.java
@@ -1,5 +1,6 @@
 package uk.gov.dhsc.htbhf.claimant.model;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -87,6 +88,7 @@ class ClaimantDTOTest extends AbstractValidationTest {
         assertThat(violations).hasSingleConstraintViolation("size must be between 1 and 500", "lastName");
     }
 
+    @Disabled("nino is optional for private beta  and unique key is yet to be decided")
     @Test
     void shouldFailValidationWithNullNino() {
         //Given
@@ -95,6 +97,26 @@ class ClaimantDTOTest extends AbstractValidationTest {
         Set<ConstraintViolation<ClaimantDTO>> violations = validator.validate(claimant);
         //Then
         assertThat(violations).hasSingleConstraintViolation("must not be null", "nino");
+    }
+
+    @Test
+    void shouldValidateWithoutNino() {
+        //Given
+        ClaimantDTO claimant = aClaimantDTOWithNino(null);
+        //When
+        Set<ConstraintViolation<ClaimantDTO>> violations = validator.validate(claimant);
+        //Then
+        assertThat(violations).hasNoViolations();
+    }
+
+    @Test
+    void shouldValidateWithoutEmailAddressAndPhoneNumber() {
+        //Given
+        ClaimantDTO claimant = aClaimantDTOWithEmailAddressAndPhoneNumber(null, null);
+        //When
+        Set<ConstraintViolation<ClaimantDTO>> violations = validator.validate(claimant);
+        //Then
+        assertThat(violations).hasNoViolations();
     }
 
     @ParameterizedTest

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/model/NewClaimDTOTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/model/NewClaimDTOTest.java
@@ -14,7 +14,8 @@ import javax.validation.ConstraintViolation;
 import static uk.gov.dhsc.htbhf.TestConstants.MAGGIE_AND_LISA_DOBS;
 import static uk.gov.dhsc.htbhf.TestConstants.NO_CHILDREN;
 import static uk.gov.dhsc.htbhf.assertions.ConstraintViolationAssert.assertThat;
-import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimantDTOTestDataFactory.aClaimantDTOWithPhoneNumber;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimantDTOTestDataFactory.aClaimantDTOWithEmailAddressAndPhoneNumber;
+import static uk.gov.dhsc.htbhf.claimant.testsupport.ClaimantDTOTestDataFactory.aClaimantDTOWithLastName;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.EligibilityOverrideDTOTestDataFactory.aConfirmedEligibilityOverrideDTOWithChildren;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.NewClaimDTOTestDataFactory.*;
 import static uk.gov.dhsc.htbhf.claimant.testsupport.TestConstants.CHILD_BORN_IN_FUTURE;
@@ -55,12 +56,23 @@ class NewClaimDTOTest extends AbstractValidationTest {
     @Test
     void shouldFailToValidateClaimWithInvalidClaimant() {
         //Given
-        ClaimantDTO claimant = aClaimantDTOWithPhoneNumber(null);
+        ClaimantDTO claimant = aClaimantDTOWithLastName(null);
         NewClaimDTO claim = aClaimDTOWithClaimant(claimant);
         //When
         Set<ConstraintViolation<NewClaimDTO>> violations = validator.validate(claim);
         //Then
-        assertThat(violations).hasSingleConstraintViolation("must not be null", "claimant.phoneNumber");
+        assertThat(violations).hasSingleConstraintViolation("must not be null", "claimant.lastName");
+    }
+
+    @Test
+    void shouldValidateClaimWithoutEmailAdderssAndPhoneNumber() {
+        //Given
+        ClaimantDTO claimant = aClaimantDTOWithEmailAddressAndPhoneNumber(null, null);
+        NewClaimDTO claim = aClaimDTOWithClaimant(claimant);
+        //When
+        Set<ConstraintViolation<NewClaimDTO>> violations = validator.validate(claim);
+        //Then
+        assertThat(violations).hasNoViolations();
     }
 
     @Test

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/scheduler/HandleCardPendingCancellationJobTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/scheduler/HandleCardPendingCancellationJobTest.java
@@ -17,6 +17,7 @@ import java.time.LocalDateTime;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static uk.gov.dhsc.htbhf.claimant.entity.CardStatus.PENDING_CANCELLATION;
 import static uk.gov.dhsc.htbhf.claimant.entity.CardStatus.SCHEDULED_FOR_CANCELLATION;
 import static uk.gov.dhsc.htbhf.claimant.message.EmailPayloadAssertions.assertEmailPayloadCorrectWithFirstAndLastName;
@@ -41,6 +42,16 @@ class HandleCardPendingCancellationJobTest {
         job.handleCardPendingCancellation(claim);
 
         assertEmailSent(claim);
+        assertClaimCardStatusUpdated();
+    }
+
+    @Test
+    public void shouldNotSendCardToBeCancelledEmailAndSetCardStatusForMissingEmail() {
+        Claim claim = aClaimWithCardStatusAndCardStatusTimestamp(PENDING_CANCELLATION, LocalDateTime.now().minusWeeks(16));
+        claim.getClaimant().setEmailAddress(null);
+        job.handleCardPendingCancellation(claim);
+
+        verifyNoInteractions(messageQueueClient);
         assertClaimCardStatusUpdated();
     }
 

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/claim/ClaimServiceTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/claim/ClaimServiceTest.java
@@ -406,6 +406,22 @@ class ClaimServiceTest {
     }
 
     @Test
+    void shouldNotReportClaimWhenTheClaimIsRejectedWithoutNino() {
+        //given
+        // an INELIGIBLE response will cause a claim to be rejected
+        EligibilityAndEntitlementDecision decision = aDecisionWithStatus(INELIGIBLE);
+        given(eligibilityAndEntitlementService.evaluateNewClaimant(any(), any())).willReturn(decision);
+        ClaimRequest request = aValidClaimRequest();
+        request.getClaimant().setNino(null);
+
+        //when
+        claimService.createClaim(request);
+
+        // then
+        verifyNoInteractions(claimMessageSender);
+    }
+
+    @Test
     void shouldHandleNullDeviceFingerprint() {
         //given
         Claimant claimant = aValidClaimant();

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/claim/ClaimServiceTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/service/claim/ClaimServiceTest.java
@@ -91,8 +91,6 @@ class ClaimServiceTest {
     private static final List<LocalDate> NULL_CHILDREN = null;
     private static final EligibilityOverride NO_ELIGIBILITY_OVERRIDE = null;
     private static final List<LocalDate> NO_CHILDREN = emptyList();
-    private static final String EMAIL_ADDRESS = "test@email.com";
-    private static final String PHONE_NUMBER = "+447123456789";
 
     private static final String WEB_UI_VERSION = "1.1.1";
 
@@ -278,19 +276,19 @@ class ClaimServiceTest {
     private static Stream<Arguments> emailOrPhoneMismatchArguments() {
         return Stream.of(
                 // email match, phone match, declared children dob, benefit agency dob, letter type
-                Arguments.of(NOT_MATCHED, MATCHED, MAGGIE_AND_LISA_DOBS, MAGGIE_AND_LISA_DOBS, APPLICATION_SUCCESS_CHILDREN_MATCH, EMAIL_ADDRESS, PHONE_NUMBER),
+                Arguments.of(NOT_MATCHED, MATCHED, MAGGIE_AND_LISA_DOBS, MAGGIE_AND_LISA_DOBS, APPLICATION_SUCCESS_CHILDREN_MATCH, HOMER_EMAIL, HOMER_MOBILE),
                 Arguments.of(NOT_HELD, MATCHED, MAGGIE_AND_LISA_DOBS, List.of(MAGGIE_DATE_OF_BIRTH), APPLICATION_SUCCESS_CHILDREN_MISMATCH,
-                        EMAIL_ADDRESS, PHONE_NUMBER),
+                        HOMER_EMAIL, HOMER_MOBILE),
                 // commented below line, currently only email matched check is added to send email and below test case won't send pending decision email in
                 // case of children mismatch however it does send only letter with partial children match
                 // Arguments.of(MATCHED, NOT_MATCHED, MAGGIE_AND_LISA_DOBS, List.of(MAGGIE_DATE_OF_BIRTH), APPLICATION_SUCCESS_CHILDREN_MISMATCH),
                 Arguments.of(NOT_MATCHED, NOT_MATCHED, MAGGIE_AND_LISA_DOBS, List.of(MAGGIE_DATE_OF_BIRTH), APPLICATION_SUCCESS_CHILDREN_MISMATCH,
-                        EMAIL_ADDRESS, PHONE_NUMBER),
-                Arguments.of(NOT_MATCHED, NOT_MATCHED, MAGGIE_AND_LISA_DOBS, emptyList(), APPLICATION_SUCCESS_CHILDREN_MISMATCH, EMAIL_ADDRESS, PHONE_NUMBER),
-                Arguments.of(NOT_MATCHED, NOT_MATCHED, emptyList(), MAGGIE_AND_LISA_DOBS, APPLICATION_SUCCESS_CHILDREN_MATCH, EMAIL_ADDRESS, PHONE_NUMBER),
+                        HOMER_EMAIL, HOMER_MOBILE),
+                Arguments.of(NOT_MATCHED, NOT_MATCHED, MAGGIE_AND_LISA_DOBS, emptyList(), APPLICATION_SUCCESS_CHILDREN_MISMATCH, HOMER_EMAIL, HOMER_MOBILE),
+                Arguments.of(NOT_MATCHED, NOT_MATCHED, emptyList(), MAGGIE_AND_LISA_DOBS, APPLICATION_SUCCESS_CHILDREN_MATCH, HOMER_EMAIL, HOMER_MOBILE),
                 Arguments.of(NOT_MATCHED, NOT_MATCHED, List.of(MAGGIE_DATE_OF_BIRTH), MAGGIE_AND_LISA_DOBS, APPLICATION_SUCCESS_CHILDREN_MATCH,
-                        EMAIL_ADDRESS, PHONE_NUMBER),
-                Arguments.of(NOT_SUPPLIED, MATCHED, MAGGIE_AND_LISA_DOBS, MAGGIE_AND_LISA_DOBS, APPLICATION_SUCCESS_CHILDREN_MATCH, null, PHONE_NUMBER),
+                        HOMER_EMAIL, HOMER_MOBILE),
+                Arguments.of(NOT_SUPPLIED, MATCHED, MAGGIE_AND_LISA_DOBS, MAGGIE_AND_LISA_DOBS, APPLICATION_SUCCESS_CHILDREN_MATCH, null, HOMER_MOBILE),
                 Arguments.of(NOT_SUPPLIED, NOT_SUPPLIED, List.of(MAGGIE_DATE_OF_BIRTH), MAGGIE_AND_LISA_DOBS, APPLICATION_SUCCESS_CHILDREN_MATCH, null, null)
         );
     }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/ClaimantDTOTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/ClaimantDTOTestDataFactory.java
@@ -35,6 +35,27 @@ public class ClaimantDTOTestDataFactory {
                 .build();
     }
 
+    public static ClaimantDTO aClaimantDTOWithEmailAddressAndPhoneNumber(String emailAddress, String phoneNumber) {
+        return aValidClaimantBuilder()
+                .emailAddress(emailAddress)
+                .phoneNumber(phoneNumber)
+                .build();
+    }
+
+    public static ClaimantDTO aClaimantDTOWithExpectedDeliveryDateAndEmailAddressAndPhoneNumber(LocalDate expectedDeliveryDate,
+                                                                                                List<LocalDate> childrenDob,
+                                                                                                String nino,
+                                                                                                String emailAddress,
+                                                                                                String phoneNumber) {
+        return aValidClaimantBuilder()
+                .nino(nino)
+                .expectedDeliveryDate(expectedDeliveryDate)
+                .initiallyDeclaredChildrenDob(childrenDob)
+                .emailAddress(emailAddress)
+                .phoneNumber(phoneNumber)
+                .build();
+    }
+
     public static ClaimantDTO aClaimantDTOWithExpectedDeliveryDate(LocalDate expectedDeliveryDate) {
         return aValidClaimantBuilder()
                 .expectedDeliveryDate(expectedDeliveryDate)

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/ClaimantTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/ClaimantTestDataFactory.java
@@ -37,6 +37,16 @@ public final class ClaimantTestDataFactory {
         return aValidClaimantBuilder().initiallyDeclaredChildrenDob(childrenDatesOfBirth).build();
     }
 
+    public static Claimant aClaimantWithChildrenDobAndEmailAddressAndPhoneNumber(List<LocalDate> childrenDatesOfBirth,
+                                                                                 String emailAddress,
+                                                                                 String phoneNumber) {
+        return aValidClaimantBuilder()
+                .initiallyDeclaredChildrenDob(childrenDatesOfBirth)
+                .emailAddress(emailAddress)
+                .phoneNumber(phoneNumber)
+                .build();
+    }
+
     public static Claimant aClaimantWithExpectedDeliveryDate(LocalDate expectedDeliveryDate) {
         return aValidClaimantBuilder().expectedDeliveryDate(expectedDeliveryDate).build();
     }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/NewClaimDTOTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/NewClaimDTOTestDataFactory.java
@@ -67,6 +67,22 @@ public final class NewClaimDTOTestDataFactory {
                 .build();
     }
 
+    public static NewClaimDTO aValidClaimDTOWithEligibilityOverrideAndNinoAndEmailAndPhone(LocalDate expectedDeliveryDate,
+                                                                    List<LocalDate> childrenDob,
+                                                                    EligibilityOutcome eligibilityOutcome,
+                                                                    LocalDate overrideUntil,
+                                                                    String nino,
+                                                                    String emailAddress,
+                                                                    String phoneNumber) {
+        EligibilityOverrideDTO eligibilityOverride = getEligibilityOverrideDTOBuilder(childrenDob, eligibilityOutcome, overrideUntil)
+                .build();
+
+        return aClaimDTOBuilder()
+                .claimant(aClaimantDTOWithExpectedDeliveryDateAndEmailAddressAndPhoneNumber(expectedDeliveryDate, childrenDob, nino, emailAddress, phoneNumber))
+                .eligibilityOverride(eligibilityOverride)
+                .build();
+    }
+
     public static NewClaimDTO aValidClaimDTOWithEligibilityOverrideForUnder18Pregnant(LocalDate expectedDeliveryDate,
                                                                                       EligibilityOutcome eligibilityOutcome,
                                                                                       LocalDate overrideUntil) {

--- a/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/RepositoryMediator.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/claimant/testsupport/RepositoryMediator.java
@@ -68,6 +68,21 @@ public class RepositoryMediator {
                 .filter(claim -> claim.getClaimant().getNino().equals(nino))
                 .map(Claim::getId)
                 .collect(Collectors.toList());
+        return getClaim(claimIds);
+    }
+
+    @Transactional
+    public Claim getClaimForLastNameAndDobAndPostCode(String lastName, LocalDate dateOfBirth, String postCode) {
+        List<UUID> claimIds = StreamSupport.stream(claimRepository.findAll().spliterator(), false)
+                .filter(claim -> claim.getClaimant().getLastName().equalsIgnoreCase(lastName))
+                .filter(claim -> claim.getClaimant().getDateOfBirth().compareTo(dateOfBirth) == 0)
+                .filter(claim -> claim.getClaimant().getAddress().getPostcode().equalsIgnoreCase(postCode))
+                .map(Claim::getId)
+                .collect(Collectors.toList());
+        return getClaim(claimIds);
+    }
+
+    private Claim getClaim(List<UUID> claimIds) {
         assertThat(claimIds).isNotEmpty();
         Optional<Claim> optional = claimRepository.findById(claimIds.get(0));
         assertThat(optional.isPresent()).isTrue();

--- a/db/src/main/resources/db/migration/V1_062__optional_nino_email_phone.sql
+++ b/db/src/main/resources/db/migration/V1_062__optional_nino_email_phone.sql
@@ -1,0 +1,8 @@
+drop index unique_nino_for_active_claim;
+
+alter table claim alter column email_address drop not null;
+alter table claim alter column phone_number drop not null;
+alter table claim alter column nino drop not null;
+
+create unique index unique_nino_for_active_claim on claim (nino)
+where claim_status in ('NEW', 'ACTIVE', 'PENDING', 'PENDING_EXPIRY') and nino is not null;


### PR DESCRIPTION
Nino is mandatory field if claim is being created without eligibility override set. if nino is not set and eligibility override is not passed then claim gets rejected being ineligible